### PR TITLE
Fix encoding of Unicode keys greater than U+00FF

### DIFF
--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -566,6 +566,8 @@ export function attach(
 
       if (key !== null) {
         if (typeof key === 'number') {
+          // unreachable code?
+          // https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js#L187
           encodedKey = new Uint8Array(1);
           encodedKey[0] = key;
         } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,7 +51,7 @@ export function getUID(): number {
   return ++uidCounter;
 }
 
-export function utfDecodeString(array: Uint8Array): string {
+export function utfDecodeString(array: Uint16Array): string {
   let string = '';
   const { length } = array;
   for (let i = 0; i < length; i++) {
@@ -60,8 +60,8 @@ export function utfDecodeString(array: Uint8Array): string {
   return string;
 }
 
-export function utfEncodeString(string: string): Uint8Array {
-  const array = new Uint8Array(string.length);
+export function utfEncodeString(string: string): Uint16Array {
+  const array = new Uint16Array(string.length);
   const { length } = string;
   for (let i = 0; i < length; i++) {
     array[i] = string.charCodeAt(i);

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,20 +51,15 @@ export function getUID(): number {
   return ++uidCounter;
 }
 
-export function utfDecodeString(array: Uint16Array): string {
-  let string = '';
-  const { length } = array;
-  for (let i = 0; i < length; i++) {
-    string += String.fromCharCode(array[i]);
-  }
-  return string;
+export function utfDecodeString(array: Uint32Array): string {
+  return String.fromCodePoint(...array);
 }
 
-export function utfEncodeString(string: string): Uint16Array {
-  const array = new Uint16Array(string.length);
-  const { length } = string;
-  for (let i = 0; i < length; i++) {
-    array[i] = string.charCodeAt(i);
-  }
-  return array;
+export function utfEncodeString(string: string): Uint32Array {
+  // $FlowFixMe Flow's Uint32Array.from's type definition is wrong; first argument of mapFn will be string
+  return Uint32Array.from(string, toCodePoint);
+}
+
+function toCodePoint(string: string) {
+  return string.codePointAt(0);
 }


### PR DESCRIPTION
Before:
```js
utfDecodeString(utfEncodeString("脳みそ爆発🤯"))
// => "3]z>/"
```

After:

```js
utfDecodeString(utfEncodeString("脳みそ爆発🤯"))
// => "脳みそ爆発🤯"
```
