### PR TITLE
Display a full-width background under a selected item

### DIFF
--- a/src/devtools/views/Element.css
+++ b/src/devtools/views/Element.css
@@ -14,8 +14,6 @@
 }
 
 .SelectedElement {
-  background-color: var(--color-tree-node-selected);
-
   /* Invert colors */
   --color-component-name: var(--color-component-name-inverted);
   --color-jsx-arrow-brackets: var(--color-jsx-arrow-brackets-inverted);

--- a/src/devtools/views/Tree.css
+++ b/src/devtools/views/Tree.css
@@ -14,15 +14,36 @@
   padding: 0.5rem;
 }
 
+.FullSize {
+  display: flex;
+  flex: 1 0 auto;
+  padding: 0.25rem;
+}
+
+.OverflowHider {
+  display: flex;
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+}
+
 .AutoSizerWrapper {
   width: 100%;
   overflow: auto;
-  flex: 1 0 auto;
-  padding: 0.25rem;
 }
 
 .List {
   font-family: var(--font-family-monospace);
   font-size: var(--font-size-monospace-normal);
   line-height: var(--line-height-data);
+}
+
+.SelectedElementBackground {
+  background-color: var(--color-tree-node-selected);
+  border-radius: 0.25em;
+  height: var(--line-height-data);
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: calc(var(--top) * 1px);
 }


### PR DESCRIPTION
- `.FullSize` is the outer-most wrapper, it has a padding
- `.OverflowHider` is inside `.FullSize`, it has `overflow: hidden` and `position: relative`
- `.AutoSizerWrapper` and `.SelectedElementBackground` are inside `.OverflowHider`

We have to listen to scroll and save it in state. Then, if there is a selected element, we can calculate the top position of `.SelectedElementBackground`.

Nothing really changes for `.AutoSizerWrapper` besides the padding that is moved to another wrapper.

I understand that this might be a bit over the top, but I think it's the simplest solution based on multi-layering.

Also `:hover` is not really handled and would require switching to JS via mouseover/mouseout handling + an additional context value. I could do that too if this will help.