### PR TITLE
Fix search element selection

### DIFF
--- a/src/devtools/views/Elements/TreeContext.js
+++ b/src/devtools/views/Elements/TreeContext.js
@@ -195,9 +195,11 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
   } = state;
 
   const prevSearchIndex = searchIndex;
+  console.log('searchIndex: ', searchIndex);
   const numPrevSearchResults = searchResults.length;
 
   // Search isn't supported when the owner's tree is active.
+  console.log('type: ', type);
   if (ownerStack.length === 0) {
     switch (type) {
       case 'GO_TO_NEXT_SEARCH_RESULT':
@@ -306,14 +308,17 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
     }
   }
 
-  if (searchIndex === null) {
-    selectedElementIndex = null;
-    selectedElementID = null;
-  } else {
-    selectedElementID = ((searchResults[searchIndex]: any): number);
-    selectedElementIndex = store.getIndexOfElementID(
-      ((selectedElementID: any): number)
-    );
+  // Changes in search index should override the selected element.
+  if (searchIndex !== prevSearchIndex || prevSearchIndex === 0) {
+    if (searchIndex === null) {
+      selectedElementIndex = null;
+      selectedElementID = null;
+    } else {
+      selectedElementID = ((searchResults[searchIndex]: any): number);
+      selectedElementIndex = store.getIndexOfElementID(
+        ((selectedElementID: any): number)
+      );
+    }
   }
 
   return {

--- a/src/devtools/views/Elements/TreeContext.js
+++ b/src/devtools/views/Elements/TreeContext.js
@@ -288,7 +288,6 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
           store.roots.forEach(rootID => {
             recursivelySearchTree(store, rootID, regExp, searchResults);
           });
-
           if (searchResults.length > 0) {
             if (prevSearchIndex === null) {
               searchIndex = 0;
@@ -307,17 +306,14 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
     }
   }
 
-  // Changes in search index should override the selected element.
-  if (searchIndex !== prevSearchIndex) {
-    if (searchIndex === null) {
-      selectedElementIndex = null;
-      selectedElementID = null;
-    } else {
-      selectedElementID = ((searchResults[searchIndex]: any): number);
-      selectedElementIndex = store.getIndexOfElementID(
-        ((selectedElementID: any): number)
-      );
-    }
+  if (searchIndex === null) {
+    selectedElementIndex = null;
+    selectedElementID = null;
+  } else {
+    selectedElementID = ((searchResults[searchIndex]: any): number);
+    selectedElementIndex = store.getIndexOfElementID(
+      ((selectedElementID: any): number)
+    );
   }
 
   return {


### PR DESCRIPTION
This fixes #26 (hopefully)

It seems that the bug reported with search selection occurs because we update `selectedElementID` inside `if` condition which is likely to fail most of the times. `searchIndex` & `prevSearchIndex` would be `0` when there are elements in `searchResults` array and they don't seem to change if user doesn't manually move to previous / next search result. And even if the `searchResults` array is updated, `searchIndex` could still be `0` and point to a different element in the tree which should be highlighted. Updating the `selectedElementID` fixes this issue. I'm not sure why was this `if` condition added and removing this would impact anything else. Please let me know if this is not the right fix :)

**Before**:

![react-devtools-experimental-search-BEFORE](https://user-images.githubusercontent.com/450559/54065428-fcec4f80-4246-11e9-81d6-806a479a2c7c.gif)

**After**:

![react-devtools-experimental-search-AFTER](https://user-images.githubusercontent.com/450559/54065432-0f668900-4247-11e9-9dde-0d0725b5049e.gif)
