### PR TITLE
Add a space in <Foo />

### DIFF
--- a/src/devtools/views/utils.js
+++ b/src/devtools/views/utils.js
@@ -12,7 +12,7 @@ export function createRegExp(string: string): RegExp {
 export function getMetaValueLabel(data: Object): string | null {
   switch (data[meta.type]) {
     case 'react_element':
-      return `<${data[meta.name]}/>`;
+      return `<${data[meta.name]} />`;
     case 'function':
       return `${data[meta.name] || 'fn'}()`;
     case 'object':


### PR DESCRIPTION
This was bugging me for a while. Makes it consistent with what we do in docs and what Prettier does.

<img width="381" alt="Screen Shot 2019-04-03 at 5 04 14 PM" src="https://user-images.githubusercontent.com/810438/55494558-e44b3b80-5632-11e9-9e5e-ca15f26aff79.png">
