### PR TITLE
Make owner stack reachable by keyboard

### DIFF
--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -206,12 +206,25 @@ function OwnerView({ displayName, id }: { displayName: string, id: number }) {
     selectElementByID,
   ]);
 
+  const handleKeyPress = useCallback(
+    e => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        selectElementByID(id);
+      }
+    },
+    [id, selectElementByID]
+  );
+
   return (
     <div
       key={id}
       className={styles.Owner}
       onClick={handleClick}
+      onKeyPress={handleKeyPress}
       title={displayName}
+      tabIndex={0}
+      role="button"
     >
       {displayName}
     </div>


### PR DESCRIPTION
We could get it "by default" by using real buttons but this also works.

It's one of the most useful navigations so seems important to get it right.

![Screen Recording 2019-04-04 at 09 53 am](https://user-images.githubusercontent.com/810438/55542803-beb84380-56bf-11e9-9618-8eb2d73ca9e5.gif)
