### PR TITLE
Allow to toggle Suspense in Components pane

### DIFF
--- a/shells/dev/app/index.js
+++ b/shells/dev/app/index.js
@@ -32,7 +32,6 @@ function mountTestApp() {
   mountHelper(ElementTypes);
   mountHelper(EditableProps);
   mountHelper(DeeplyNestedComponents);
-  mountHelper(SuspenseTree);
 }
 
 function unmountTestApp() {

--- a/shells/dev/app/index.js
+++ b/shells/dev/app/index.js
@@ -32,6 +32,7 @@ function mountTestApp() {
   mountHelper(ElementTypes);
   mountHelper(EditableProps);
   mountHelper(DeeplyNestedComponents);
+  mountHelper(SuspenseTree);
 }
 
 function unmountTestApp() {

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -38,6 +38,12 @@ type SetInParams = {|
   value: any,
 |};
 
+type OverrideSuspenseParams = {|
+  id: number,
+  rendererID: number,
+  forceFallback: boolean,
+|};
+
 export default class Agent extends EventEmitter {
   _bridge: Bridge = ((null: any): Bridge);
   _isProfiling: boolean = false;
@@ -68,6 +74,7 @@ export default class Agent extends EventEmitter {
     bridge.addListener('overrideHookState', this.overrideHookState);
     bridge.addListener('overrideProps', this.overrideProps);
     bridge.addListener('overrideState', this.overrideState);
+    bridge.addListener('overrideSuspense', this.overrideSuspense);
     bridge.addListener('reloadAndProfile', this.reloadAndProfile);
     bridge.addListener('screenshotCaptured', this.screenshotCaptured);
     bridge.addListener('selectElement', this.selectElement);
@@ -299,6 +306,19 @@ export default class Agent extends EventEmitter {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
       renderer.setInState(id, path, value);
+    }
+  };
+
+  overrideSuspense = ({
+    id,
+    rendererID,
+    forceFallback,
+  }: OverrideSuspenseParams) => {
+    const renderer = this._rendererInterfaces[rendererID];
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+    } else {
+      renderer.overrideSuspense(id, forceFallback);
     }
   };
 

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -210,11 +210,8 @@ export default class Agent extends EventEmitter {
     }
 
     let node: HTMLElement | null = null;
-    if (
-      renderer !== null &&
-      typeof renderer.getNativeFromReactElement === 'function'
-    ) {
-      node = ((renderer.getNativeFromReactElement(id): any): HTMLElement);
+    if (renderer !== null) {
+      node = ((renderer.findNativeByFiberID(id): any): HTMLElement);
     }
 
     if (node != null) {

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -226,7 +226,7 @@ export function attach(
     setSuspenseHandler,
     scheduleUpdate,
   } = renderer;
-  const supportsEditingSuspense =
+  const supportsTogglingSuspense =
     typeof setSuspenseHandler === 'function' &&
     typeof scheduleUpdate === 'function';
 
@@ -1443,8 +1443,8 @@ export function attach(
       // Does the current renderer support editable function props?
       canEditFunctionProps: typeof overrideProps === 'function',
 
-      canEditSuspense:
-        supportsEditingSuspense &&
+      canToggleSuspense:
+        supportsTogglingSuspense &&
         // If it's showing the real content, we can always flip fallback.
         (!isTimedOutSuspense ||
           // If it's showing fallback because we previously forced it to,

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -45,6 +45,10 @@ export type ReactRenderer = {
     value: any
   ) => void,
 
+  // 16.9+
+  scheduleUpdate?: ?(fiber: Object) => void,
+  setSuspenseHandler?: ?(shouldSuspend: (fiber: Object) => boolean) => void,
+
   // Only injected by React v16.8+ in order to support hooks inspection.
   currentDispatcherRef?: {| current: null | Dispatcher |},
 };
@@ -95,6 +99,7 @@ export type RendererInterface = {
   handleCommitFiberRoot: (fiber: Object) => void,
   handleCommitFiberUnmount: (fiber: Object) => void,
   inspectElement: (id: number) => InspectedElement | null,
+  overrideSuspense: (id: number, forceFallback: boolean) => void,
   prepareViewElementSource: (id: number) => void,
   renderer: ReactRenderer | null,
   selectElement: (id: number) => void,

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -86,9 +86,9 @@ export type ProfilingSummary = {|
 
 export type RendererInterface = {
   cleanup: () => void,
+  findNativeByFiberID: (id: number) => ?NativeType,
   flushInitialOperations: () => void,
   getCommitDetails: (rootID: number, commitIndex: number) => CommitDetails,
-  getNativeFromReactElement?: ?(component: Fiber) => ?NativeType,
   getFiberIDFromNative: (
     component: NativeType,
     findNearestUnfilteredAncestor?: boolean

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -126,7 +126,7 @@ function InspectedElementView({
   const {
     canEditFunctionProps,
     canEditHooks,
-    canEditSuspense,
+    canToggleSuspense,
     context,
     hooks,
     owners,
@@ -165,7 +165,7 @@ function InspectedElementView({
       const rendererID = store.getRendererIDForElement(id);
       bridge.send('overrideProps', { id, path, rendererID, value });
     };
-  } else if (type === ElementTypeSuspense && canEditSuspense) {
+  } else if (type === ElementTypeSuspense && canToggleSuspense) {
     overrideSuspenseFn = (path: Array<string | number>, value: boolean) => {
       if (path.length !== 1 && path !== IS_SUSPENDED) {
         throw new Error('Unexpected path.');

--- a/src/devtools/views/Components/types.js
+++ b/src/devtools/views/Components/types.js
@@ -41,6 +41,9 @@ export type InspectedElement = {|
   // Does the current renderer support editable function props?
   canEditFunctionProps: boolean,
 
+  // Is this Suspense, and can its value be overriden now?
+  canEditSuspense: boolean,
+
   // Can view component source location.
   canViewSource: boolean,
 

--- a/src/devtools/views/Components/types.js
+++ b/src/devtools/views/Components/types.js
@@ -42,7 +42,7 @@ export type InspectedElement = {|
   canEditFunctionProps: boolean,
 
   // Is this Suspense, and can its value be overriden now?
-  canEditSuspense: boolean,
+  canToggleSuspense: boolean,
 
   // Can view component source location.
   canViewSource: boolean,


### PR DESCRIPTION
Supersedes https://github.com/bvaughn/react-devtools-experimental/pull/36.

Fixes https://github.com/bvaughn/react-devtools-experimental/issues/60.

This is MVP support for toggling Suspense from the Components pane. We plan a separate tab in https://github.com/bvaughn/react-devtools-experimental/issues/43 but we'd want a way to quickly debug it anyway so seems like this is a good first step.

## Showing Suspense Status

Currently, Suspense shows Fiber internal state in the "state" section of the inspector (when Suspended), and nothing if unsuspended. This PR changes so that we show the current Suspense state:

![Screen Recording 2019-04-04 at 03 29 PM](https://user-images.githubusercontent.com/810438/55563951-c5aa7a80-56ee-11e9-8940-7fd5ae760e69.gif)

This works with older versions of React.

## Toggling Suspense Status

The inspected value turns into a checkbox if:

* You're using a version of React that includes https://github.com/facebook/react/pull/15232, **AND**
  - The component is not currently Suspended, **OR**
  - You've previously pressed the checkbox to force it to Suspend.

This means that you can toggle Suspense on and off. But if a component actually Suspends by itself, there's nothing to show in the "current" state. In that case the checkbox becomes a read-only label again until it un-Suspends.

Alternatively, we could separate the "current value" from the "override value". But I feel like this is sufficient and intuitive enough in practice after playing with it.

![Screen Recording 2019-04-04 at 03 36 PM](https://user-images.githubusercontent.com/810438/55564313-87fa2180-56ef-11e9-9818-b2a54f7b1137.gif)

## Implementation

The simplest implementation would be to always `setSuspenseHandler()` to the thing that checks IDs in the Set. However, I don't want to incur any Set checking overhead if none of the Suspenses were manually toggled. So I attach and detach the Set-checking handler on demand.