### PR TITLE
Move selection when typing in search field

### DIFF
--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -195,6 +195,7 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
   } = state;
 
   const prevSearchIndex = searchIndex;
+  const prevSearchText = searchText;
   const numPrevSearchResults = searchResults.length;
 
   // Search isn't supported when the owner's tree is active.
@@ -307,8 +308,8 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
     }
   }
 
-  // Changes in search index should override the selected element.
-  if (searchIndex !== prevSearchIndex) {
+  // Changes in search index or typing should override the selected element.
+  if (searchIndex !== prevSearchIndex || searchText.indexOf(prevSearchText) === 0) {
     if (searchIndex === null) {
       selectedElementIndex = null;
       selectedElementID = null;


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/26.

I noticed search often selects a random item.

But looking closer, it was because of a partial match:

![1](https://user-images.githubusercontent.com/810438/55566008-c6dda680-56f2-11e9-83ee-c3a2a5581772.gif)

This changes the algorithm to also change the selection if you continue typing in the search field. I think this feels better. It also matches what Chrome does in text search more closely. (Although not quite — but implementing 1:1 mapping seems like too much complexity right now.)

![2](https://user-images.githubusercontent.com/810438/55566029-ccd38780-56f2-11e9-805a-1a49358003ab.gif)
