### PR TITLE
Match search at word boundaries

### DIFF
--- a/src/devtools/views/Components/SearchInput.js
+++ b/src/devtools/views/Components/SearchInput.js
@@ -95,7 +95,7 @@ export default function SearchInput(props: Props) {
         onChange={handleTextChange}
         onKeyDown={handleKeyDown}
         onKeyPress={handleInputKeyPress}
-        placeholder="Search (text or /regex/)"
+        placeholder="Search"
         ref={inputRef}
         value={searchText}
       />

--- a/src/devtools/views/Components/SearchInput.js
+++ b/src/devtools/views/Components/SearchInput.js
@@ -95,7 +95,7 @@ export default function SearchInput(props: Props) {
         onChange={handleTextChange}
         onKeyDown={handleKeyDown}
         onKeyPress={handleInputKeyPress}
-        placeholder="Search"
+        placeholder="Search (text or /regex/)"
         ref={inputRef}
         value={searchText}
       />

--- a/src/devtools/views/utils.js
+++ b/src/devtools/views/utils.js
@@ -6,6 +6,23 @@ import { meta } from '../../hydration';
 import type { HooksTree } from 'src/backend/types';
 
 export function createRegExp(string: string): RegExp {
+  // Allow /regex/ syntax with optional last /
+  if (string[0] === '/') {
+    // Cut off first slash
+    string = string.substring(1);
+    // Cut off last slash, but only if it's there
+    if (string[string.length - 1] === '/') {
+      string = string.substring(0, string.length - 1);
+    }
+    try {
+      return new RegExp(string, 'i');
+    } catch (err) {
+      // Bad regex. Make it not match anything.
+      // TODO: maybe warn in console?
+      return new RegExp('.^');
+    }
+  }
+
   function isLetter(char: string) {
     return char.toLowerCase() !== char.toUpperCase();
   }

--- a/src/devtools/views/utils.js
+++ b/src/devtools/views/utils.js
@@ -6,7 +6,34 @@ import { meta } from '../../hydration';
 import type { HooksTree } from 'src/backend/types';
 
 export function createRegExp(string: string): RegExp {
-  return new RegExp(escapeStringRegExp(string), 'i');
+  // 'item' should match 'Item' and 'ListItem', but not 'InviteMom'.
+  // To do this, we'll slice off 'tem' and check first letter separately.
+  const escaped = escapeStringRegExp(string);
+  const firstLetter = escaped[0];
+  let restRegex = '';
+  // For 'item' input, restRegex becomes '[tT][eE][mM]'
+  // We can't simply make it case-insensitive because first letter case matters.
+  for (let i = 1; i < escaped.length; i++) {
+    const char = escaped[i];
+    restRegex += '[' + char.toLowerCase() + char.toUpperCase() + ']';
+  }
+  // Respect first letter only if it starts a word.
+  return new RegExp(
+    // For example:
+    // (^[iI]|I)[tT][eE][mM]
+    // Matches:
+    // 'Item'
+    // 'ListItem'
+    // but not 'InviteMom'
+    '(^[' +
+      firstLetter +
+      firstLetter.toLowerCase() +
+      ']' +
+      '|' +
+      firstLetter.toUpperCase() +
+      ')' +
+      restRegex
+  );
 }
 
 export function getMetaValueLabel(data: Object): string | null {

--- a/src/devtools/views/utils.js
+++ b/src/devtools/views/utils.js
@@ -26,8 +26,8 @@ export function createRegExp(string: string): RegExp {
     // 'ListItem'
     // but not 'InviteMom'
     '(^[' +
-      firstLetter +
       firstLetter.toLowerCase() +
+      firstLetter.toUpperCase() +
       ']' +
       '|' +
       firstLetter.toUpperCase() +


### PR DESCRIPTION
This makes searching a bit more robust.

Previously, `item` would match both `*Item*`, `List*Item*`, and `Iniv*iteM*om`.

I've changed regex to only consider a match if the first query letter is either at the beginning of the component name (such as the case with `Item`), or if it is at the word boundary (like in `ListItem`). Matches in the middle of the name where the first letter appears as lowercase are ignored.

This prevents matching `c` to `InteractionTracking`, for example:

![Screen Recording 2019-04-04 at 04 25 PM](https://user-images.githubusercontent.com/810438/55567835-6badb300-56f6-11e9-8328-69c2d1fdce1f.gif)

## Implementation

See comments. To make this work, I had to make the regex case-sensitive. Instead, I expand the casings directly when building regex, and add a special case for the first letter.

`Listitem` would still match `ListItem`. Only the first letter in the target text is treated contextually.