### PR TITLE
Don't crash for deeply nested Hooks

### DIFF
--- a/shells/dev/app/InspectableElements/CustomHooks.js
+++ b/shells/dev/app/InspectableElements/CustomHooks.js
@@ -32,6 +32,13 @@ function useCustomObject() {
   return useState(123);
 }
 
+function useVeryDeeplyNestedHook(i) {
+  useDebugValue(i);
+  if (i > 0) {
+    useVeryDeeplyNestedHook(i - 1);
+  }
+}
+
 function FunctionWithHooks(props: any, ref: React$Ref<any>) {
   const [count, updateCount] = useState(0);
 
@@ -52,6 +59,9 @@ function FunctionWithHooks(props: any, ref: React$Ref<any>) {
 
   // Tests nested custom hooks
   useNestedOuterHook();
+
+  // Verify deep nesting doesn't break
+  useVeryDeeplyNestedHook(50);
 
   return <button onClick={onClick}>Count: {debouncedCount}</button>;
 }

--- a/shells/dev/app/InspectableElements/NestedProps.js
+++ b/shells/dev/app/InspectableElements/NestedProps.js
@@ -23,6 +23,29 @@ export default function ObjectProps() {
       array={['first', 'second', 'third']}
       objectInArray={[object]}
       arrayInObject={{ array: ['first', 'second', 'third'] }}
+      deepObject={{
+        // Known limitation: we won't go deeper than several levels.
+        // In the future, we might offer a way to request deeper access on demand.
+        a: {
+          b: {
+            c: {
+              d: {
+                e: {
+                  f: {
+                    g: {
+                      h: {
+                        i: {
+                          j: 10,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }}
     />
   );
 }

--- a/src/devtools/views/Components/HooksTree.js
+++ b/src/devtools/views/Components/HooksTree.js
@@ -9,6 +9,7 @@ import EditableValue from './EditableValue';
 import KeyValue from './KeyValue';
 import { serializeHooksForCopy } from '../utils';
 import styles from './HooksTree.css';
+import { meta } from '../../../hydration';
 
 import type { HooksNode, HooksTree } from 'src/backend/types';
 
@@ -71,6 +72,11 @@ type HookViewProps = {|
 
 function HookView({ canEditHooks, hook, id, path = [] }: HookViewProps) {
   const { name, id: hookID, isStateEditable, subHooks, value } = hook;
+  if (hook.hasOwnProperty(meta.inspected)) {
+    // This Hook is too deep and hasn't been hydrated.
+    // TODO: show UI to load its data.
+    return null;
+  }
 
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/42.

This happened because the code didn't handle the dehydrated case, and the hydration level constant is set at `6`. (Which is a few levels of custom Hooks + a few levels of `subHooks` arrays.)

The fix includes a few stress tests. The nested deep Hook one used to crash, but doesn't anymore.

<img width="330" alt="Screen Shot 2019-04-04 at 7 24 47 PM" src="https://user-images.githubusercontent.com/810438/55579245-b4259a80-570f-11e9-8254-3a7d4f41d4d0.png">

It's not ideal that we don't let you inspect deeper. But this can be fixed later with a UI that loads them on demand. I added todos for that.