### PR TITLE
Bump font size of owner stack items

### DIFF
--- a/src/devtools/views/Components/SelectedElement.css
+++ b/src/devtools/views/Components/SelectedElement.css
@@ -32,6 +32,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--color-component-name);
+  font-size: var(--font-size-sans-normal);
 }
 .Component:before,
 .Owner:before {

--- a/src/devtools/views/Components/SelectedElement.css
+++ b/src/devtools/views/Components/SelectedElement.css
@@ -32,7 +32,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--color-component-name);
-  font-size: var(--font-size-sans-normal);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-normal);
 }
 .Component:before,
 .Owner:before {


### PR DESCRIPTION
Not sure if you intentionally made it smaller or it was accidental.

With Comfortable layout, they're currently 11px — which IMO is a bit too small, at least for Comfortable. This adds the closest constant I found. I don't mind them being a bit smaller than that, but IMO they're way too small right now, at least for a Comfortable mode, to the point of being hard to read.

Thanks for considering.