### PR TITLE
Stop mouseup propagation while inspecting

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -320,6 +320,7 @@ export default class Agent extends EventEmitter {
   startInspectingDOM = () => {
     window.addEventListener('click', this._onClick, true);
     window.addEventListener('mousedown', this._onMouseDown, true);
+    window.addEventListener('mouseup', this._onMouseUp, true);
     window.addEventListener('mouseover', this._onMouseOver, true);
   };
 
@@ -339,6 +340,7 @@ export default class Agent extends EventEmitter {
 
     window.removeEventListener('click', this._onClick, true);
     window.removeEventListener('mousedown', this._onMouseDown, true);
+    window.removeEventListener('mouseup', this._onMouseUp, true);
     window.removeEventListener('mouseover', this._onMouseOver, true);
   };
 
@@ -406,6 +408,14 @@ export default class Agent extends EventEmitter {
     if (id !== null) {
       this._bridge.send('selectFiber', id);
     }
+  };
+
+  // While we don't do anything here, this makes choosing
+  // the inspected element less invasive and less likely
+  // to dismiss e.g. a context menu.
+  _onMouseUp = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
   };
 
   _onMouseOver = (event: MouseEvent) => {


### PR DESCRIPTION
I noticed that in some places on FB, "selecting" an element inside a context menu will dismiss the menu. While we stop `click` and `mousedown` propagation, we didn't stop `mouseup`. Our handlers listen to it.

This makes clicking the page to choose a DOM element a bit less likely to blow away the thing you're trying to inspect — by preventing `mouseup` propagation too until your click is done.