### PR TITLE
Explicitly guard debug calls

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -365,7 +365,9 @@ export default class Agent extends EventEmitter {
   };
 
   onHookOperations = (operations: Uint32Array) => {
-    debug('onHookOperations', operations);
+    if (__DEBUG__) {
+      debug('onHookOperations', operations);
+    }
 
     // TODO:
     // The chrome.runtime does not currently support transferables; it forces JSON serialization.

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -735,7 +735,9 @@ export function attach(
   }
 
   function mountFiber(fiber: Fiber, parentFiber: Fiber | null) {
-    debug('mountFiber()', fiber, parentFiber);
+    if (__DEBUG__) {
+      debug('mountFiber()', fiber, parentFiber);
+    }
 
     const shouldEnqueueMount = !shouldFilterFiber(fiber);
 
@@ -756,7 +758,9 @@ export function attach(
     fiber: Fiber,
     hasChildOrderChanged: boolean
   ) {
-    debug('enqueueUpdateIfNecessary()', fiber);
+    if (__DEBUG__) {
+      debug('enqueueUpdateIfNecessary()', fiber);
+    }
 
     const isProfilingSupported = fiber.hasOwnProperty('treeBaseDuration');
     if (isProfilingSupported) {
@@ -833,7 +837,9 @@ export function attach(
     prevFiber: Fiber,
     parentFiber: Fiber | null
   ) {
-    debug('enqueueUpdateIfNecessary()', nextFiber, parentFiber);
+    if (__DEBUG__) {
+      debug('enqueueUpdateIfNecessary()', nextFiber, parentFiber);
+    }
 
     const shouldEnqueueUpdate = !shouldFilterFiber(nextFiber);
 

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -110,7 +110,9 @@ export default class Store extends EventEmitter {
   constructor(bridge: Bridge, config?: Config) {
     super();
 
-    debug('constructor', 'subscribing to Bridge');
+    if (__DEBUG__) {
+      debug('constructor', 'subscribing to Bridge');
+    }
 
     if (config != null) {
       const {
@@ -433,7 +435,9 @@ export default class Store extends EventEmitter {
       operations = Uint32Array.from(Object.values(operations));
     }
 
-    debug('onBridgeOperations', operations);
+    if (__DEBUG__) {
+      debug('onBridgeOperations', operations);
+    }
 
     let haveRootsChanged = false;
 
@@ -479,7 +483,9 @@ export default class Store extends EventEmitter {
           i = i + 3;
 
           if (type === ElementTypeRoot) {
-            debug('Add', `new root fiber ${id}`);
+            if (__DEBUG__) {
+              debug('Add', `new root fiber ${id}`);
+            }
 
             if (this._idToElement.has(id)) {
               // The renderer's tree walking approach sometimes mounts the same Fiber twice with Suspense and Lazy.
@@ -532,10 +538,12 @@ export default class Store extends EventEmitter {
                 : utfDecodeString((operations.slice(i, i + keyLength): any));
             i += +keyLength;
 
-            debug(
-              'Add',
-              `fiber ${id} (${displayName || 'null'}) as child of ${parentID}`
-            );
+            if (__DEBUG__) {
+              debug(
+                'Add',
+                `fiber ${id} (${displayName || 'null'}) as child of ${parentID}`
+              );
+            }
 
             if (this._idToElement.has(id)) {
               // The renderer's tree walking approach sometimes mounts the same Fiber twice with Suspense and Lazy.
@@ -582,7 +590,9 @@ export default class Store extends EventEmitter {
 
           parentElement = ((this._idToElement.get(parentID): any): Element);
           if (parentElement == null) {
-            debug('Remove', `fiber ${id} root`);
+            if (__DEBUG__) {
+              debug('Remove', `fiber ${id} root`);
+            }
 
             this._roots = this._roots.filter(rootID => rootID !== id);
             this._rootIDToRendererID.delete(id);
@@ -590,7 +600,9 @@ export default class Store extends EventEmitter {
 
             haveRootsChanged = true;
           } else {
-            debug('Remove', `fiber ${id} from parent ${parentID}`);
+            if (__DEBUG__) {
+              debug('Remove', `fiber ${id} from parent ${parentID}`);
+            }
 
             parentElement.children = parentElement.children.filter(
               childID => childID !== id
@@ -613,7 +625,9 @@ export default class Store extends EventEmitter {
 
           i = i + 3 + numChildren;
 
-          debug('Re-order', `fiber ${id} children ${children.join(',')}`);
+          if (__DEBUG__) {
+            debug('Re-order', `fiber ${id} children ${children.join(',')}`);
+          }
 
           element = ((this._idToElement.get(id): any): Element);
           element.children = Array.from(children);
@@ -692,7 +706,9 @@ export default class Store extends EventEmitter {
   };
 
   onBridgeShutdown = () => {
-    debug('onBridgeShutdown', 'unsubscribing from Bridge');
+    if (__DEBUG__) {
+      debug('onBridgeShutdown', 'unsubscribing from Bridge');
+    }
 
     this._bridge.removeListener('operations', this.onBridgeOperations);
     this._bridge.removeListener('profilingStatus', this.onProfilingStatus);

--- a/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -186,7 +186,9 @@ function updateTree(
         if (type === ElementTypeRoot) {
           i++; // supportsProfiling flag
 
-          debug('Add', `new root fiber ${id}`);
+          if (__DEBUG__) {
+            debug('Add', `new root fiber ${id}`);
+          }
 
           if (nodes.has(id)) {
             // The renderer's tree walking approach sometimes mounts the same Fiber twice with Suspense and Lazy.
@@ -233,10 +235,12 @@ function updateTree(
             // For now, we avoid adding it to the tree twice by checking if it's already been mounted.
             // Maybe in the future we'll revisit this.
           } else {
-            debug(
-              'Add',
-              `fiber ${id} (${displayName || 'null'}) as child of ${parentID}`
-            );
+            if (__DEBUG__) {
+              debug(
+                'Add',
+                `fiber ${id} (${displayName || 'null'}) as child of ${parentID}`
+              );
+            }
 
             parentNode = getClonedNode(parentID);
             parentNode.children = parentNode.children.concat(id);
@@ -268,7 +272,9 @@ function updateTree(
         if (parentNode == null) {
           // No-op
         } else {
-          debug('Remove', `fiber ${id} from parent ${parentID}`);
+          if (__DEBUG__) {
+            debug('Remove', `fiber ${id} from parent ${parentID}`);
+          }
 
           parentNode.children = parentNode.children.filter(
             childID => childID !== id
@@ -285,7 +291,9 @@ function updateTree(
 
         i = i + 3 + numChildren;
 
-        debug('Re-order', `fiber ${id} children ${children.join(',')}`);
+        if (__DEBUG__) {
+          debug('Re-order', `fiber ${id} children ${children.join(',')}`);
+        }
 
         node = getClonedNode(id);
         node.children = Array.from(children);
@@ -297,10 +305,12 @@ function updateTree(
         node = getClonedNode(id);
         node.treeBaseDuration = operations[i + 2] / 1000; // Convert microseconds back to milliseconds;
 
-        debug(
-          'Update',
-          `fiber ${id} treeBaseDuration to ${node.treeBaseDuration}`
-        );
+        if (__DEBUG__) {
+          debug(
+            'Update',
+            `fiber ${id} treeBaseDuration to ${node.treeBaseDuration}`
+          );
+        }
 
         i = i + 3;
         break;


### PR DESCRIPTION
I understand the convenience but without a Babel plugin it seems a bit too easy to accidentally cause extra work. Such as the `children.join(',')` we're doing on every reorder — afaik, in production too.

This is a bit noisy but seems easy enough to follow and avoids that. I added everywhere for consistency.