### PR TITLE
Don't move selection unless search text increased length

### DIFF
--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -309,10 +309,10 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
   }
 
   // Changes in search index or typing should override the selected element.
-  if (
-    searchIndex !== prevSearchIndex ||
-    searchText.indexOf(prevSearchText) === 0
-  ) {
+  const didAddToSearchText =
+    searchText.length > prevSearchText.length &&
+    searchText.indexOf(prevSearchText) === 0;
+  if (searchIndex !== prevSearchIndex || didAddToSearchText) {
     if (searchIndex === null) {
       selectedElementIndex = null;
       selectedElementID = null;


### PR DESCRIPTION
This fixes the "disappearing selection" problem you found in https://github.com/bvaughn/react-devtools-experimental/pull/61#discussion_r272360830.

I introduced it in https://github.com/bvaughn/react-devtools-experimental/pull/62. The mistake is that moving from `''` to `''` in search field shouldn't reset. Only _increasing_ the search field should.