### PR TITLE
RFC (not for merge): Show owner tree by default

### DIFF
--- a/shells/dev/app/ElementTypes/index.js
+++ b/shells/dev/app/ElementTypes/index.js
@@ -10,7 +10,7 @@ import React, {
   unstable_ConcurrentMode as ConcurrentMode,
   Fragment,
   // $FlowFixMe Flow doesn't know about the Profiler import yet
-  unstable_Profiler as Profiler,
+  Profiler,
   StrictMode,
   Suspense,
 } from 'react';

--- a/src/devtools/views/Components/OwnersStack.js
+++ b/src/devtools/views/Components/OwnersStack.js
@@ -1,31 +1,38 @@
 // @flow
 
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect, useState, useRef } from 'react';
 import Button from '../Button';
-import ButtonIcon from '../ButtonIcon';
+import Icon from '../Icon';
 import { TreeContext } from './TreeContext';
-import { StoreContext } from '../context';
+import { BridgeContext, StoreContext } from '../context';
+import { hydrate } from 'src/hydration';
 
 import type { Element } from './types';
 
 import styles from './OwnersStack.css';
 
-export default function OwnerStack() {
-  const { ownerStack, resetOwnerStack } = useContext(TreeContext);
+export default function OwnerStack({ onSearchClick }) {
+  const { selectedElementID } = useContext(TreeContext);
+  const bridge = useContext(BridgeContext);
+  const store = useContext(StoreContext);
+  const inspectedElement = useInspectedElement(selectedElementID);
+  if (!inspectedElement) {
+    return null
+  }
+  const {owners} = inspectedElement;
+  if (!owners) {
+    return null
+  }
 
-  const elements = ownerStack.map((id, index) => (
+  const elements = owners.reverse().map(({id}, index) => (
     <ElementView key={id} id={id} index={index} />
   ));
 
   return (
     <div className={styles.OwnerStack}>
-      <Button
-        className={styles.IconButton}
-        onClick={resetOwnerStack}
-        title="Back to tree view"
-      >
-        <ButtonIcon type="close" />
-      </Button>
+      <div onClick={onSearchClick}>
+        <Icon className={styles.InputIcon} type="search" /> 
+      </div>
       <div className={styles.VRule} />
       {elements}
     </div>
@@ -58,4 +65,75 @@ function ElementView({ id, index }: Props) {
       {displayName}
     </button>
   );
+}
+
+
+function useInspectedElement(id: number | null): InspectedElement | null {
+  const idRef = useRef(id);
+  const bridge = useContext(BridgeContext);
+  const store = useContext(StoreContext);
+
+  const [inspectedElement, setInspectedElement] = useState(null);
+
+  useEffect(() => {
+    // Track the current selected element ID.
+    // We ignore any backend updates about previously selected elements.
+    idRef.current = id;
+
+    // Hide previous/stale insepected element to avoid temporarily showing the wrong values.
+    setInspectedElement(null);
+
+    // A null id indicates that there's nothing currently selected in the tree.
+    if (id === null) {
+      return () => {};
+    }
+
+    const rendererID = store.getRendererIDForElement(id) || null;
+
+    // Update the $r variable.
+    bridge.send('selectElement', { id, rendererID });
+
+    // Update props, state, and context in the side panel.
+    const sendBridgeRequest = () => {
+      bridge.send('inspectElement', { id, rendererID });
+    };
+
+    let timeoutID = null;
+
+    const onInspectedElement = (inspectedElement: InspectedElement) => {
+      if (!inspectedElement || inspectedElement.id !== idRef.current) {
+        // Ignore bridge updates about previously selected elements.
+        return;
+      }
+
+      setInspectedElement(inspectedElement);
+
+      // Ask for an update in a second.
+      // Make sure we only ask once though.
+      clearTimeout(((timeoutID: any): TimeoutID));
+      setTimeout(sendBridgeRequest, 1000);
+    };
+
+    bridge.addListener('inspectedElement', onInspectedElement);
+
+    sendBridgeRequest();
+
+    return () => {
+      bridge.removeListener('inspectedElement', onInspectedElement);
+
+      if (timeoutID !== null) {
+        clearTimeout(timeoutID);
+      }
+    };
+  }, [bridge, id, idRef, store]);
+
+  return inspectedElement;
+}
+
+function hydrateHelper(dehydratedData: DehydratedData | null): Object | null {
+  if (dehydratedData !== null) {
+    return hydrate(dehydratedData.data, dehydratedData.cleaned);
+  } else {
+    return null;
+  }
 }

--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useMemo,
   useLayoutEffect,
+  useState,
   useRef,
 } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -34,6 +35,7 @@ export default function Tree(props: Props) {
   } = useContext(TreeContext);
   const listRef = useRef<FixedSizeList<any> | null>(null);
   const treeRef = useRef<HTMLDivElement | null>(null);
+  const [searching, setSearching] = useState(false)
 
   const { lineHeight } = useContext(SettingsContext);
 
@@ -105,7 +107,10 @@ export default function Tree(props: Props) {
   return (
     <div className={styles.Tree} ref={treeRef}>
       <div className={styles.SearchInput}>
-        {ownerStack.length > 0 ? <OwnersStack /> : <SearchInput />}
+        {searching ?
+          <SearchInput />
+          : <OwnersStack onSearchClick={() => setSearching(true)} />
+        }
         <InspectHostNodesToggle />
       </div>
       <div className={styles.AutoSizerWrapper}>


### PR DESCRIPTION
### Note: Ignore the code, it's super hacky and doesn't really work except for a five second demo

Currently we have two places where owner tree shows up:

* Right pane
* In "owner mode" (which you enter with a double click)

I wonder if we could make it more prominent as it gives such a great bird eye's view of where you are, especially in giant trees.

The downside of the right pane is that it's buried under props and state so you often have to scroll down for it. The "owner stack" thing vertical position is always different so it's hard to train to see it quickly. Additionally, the "navigation" mostly happens on the left side already. I'm not proposing to remove the right pane but I wish there was a quicker way to find where I am.

The double-click "owner mode" is neat but I'd use it to *focus* on some part of the hierarchy. However, in large trees I often don't even know what I'm looking at. Is that the right or the wrong part?

**I wish I could quickly tell where the selected element roughly is in the tree without performing either scrolling or double-clicking (which moves me into a totally different mode)**.

One could argue we don't have space for breadcrumbs. But we do have the Search input. It's useful while you're searching — but when it's empty, it just takes up vertical space. I need to click to search either way, so it's not saving me much time by being large.

My proposal is to make some variation of the owner tree stack visible *by default* in the top bar. There would be a "search button" that moves you into the search mode (in which case you would see the current search UI). Exiting search mode would give you the breadcrumbs back. And the existing "owner mode" would just be a "focused" variation of the main mode where you only see a particular subtree.

This gif and PR is a very poor (literally, it will hang your browser in a few seconds) prototype of how that could feel. Notice that even though it's super janky (which we could fix), you get some sense of how the tree is structured from a single look.

![Screen Recording 2019-04-06 at 05 33 pm](https://user-images.githubusercontent.com/810438/55672391-6e450f80-5892-11e9-90cf-87fefe376912.gif)

Is this a bad idea?

If there is interest, I can take a shot at implementing a real version.