### PR TITLE
Preserve selection on exiting owner mode

### DIFF
--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -383,7 +383,10 @@ function reduceOwnersState(store: Store, state: State, action: Action): State {
     case 'RESET_OWNER_STACK':
       ownerStack = [];
       ownerStackIndex = null;
-      selectedElementIndex = null;
+      selectedElementIndex =
+        selectedElementID !== null
+          ? store.getIndexOfElementID(selectedElementID)
+          : null;
       _ownerFlatTree = null;
       break;
     case 'SELECT_ELEMENT_AT_INDEX':


### PR DESCRIPTION
The owner mode is very cool but I barely use it because exiting it loses the context of where I was. This fixes it so that the last selected node stays selected when you exit the owner stack mode.

![Screen Recording 2019-04-07 at 05 37 pm](https://user-images.githubusercontent.com/810438/55686708-779aae80-595c-11e9-800a-e04a5c1a855a.gif)
