### PR TITLE
Bump overscan to 3

### DIFF
--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -118,6 +118,7 @@ export default function Tree(props: Props) {
               itemCount={numElements}
               itemData={itemData}
               itemSize={lineHeight}
+              overscanCount={3}
               ref={listRef}
               width={width}
             >


### PR DESCRIPTION
While this is subjective and depends on the laptop etc, I find this a bit less janky on fast scrolling. Rendering rows should be pretty cheap regardless (since we don't put much there) and I don't see regressions on large trees. WDYT?