### PR TITLE
Remove tree focus ring

### DIFF
--- a/src/devtools/views/Components/Tree.css
+++ b/src/devtools/views/Components/Tree.css
@@ -24,10 +24,6 @@
   font-family: var(--font-family-monospace);
   font-size: var(--font-size-monospace-normal);
   line-height: var(--line-height-data);
-  border: 0.25rem solid transparent;
-}
-.List:focus-within {
-  border-color: var(--color-button-background-focus);
 }
 
 .InnerElementType:focus {


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/80.

I figured this ring isn't really that useful because the first time you Tab into the tree, the first item gets selected. So you know it received focus. Chrome tree view doesn't have a focus ring either.

In the future, we might want to only enable tree arrow key navigation when the tree if focused. For example, that would allow us to repurpose up/down for owner stack navigation when owner stack is focused. If we were to do that, we could mark "focused" state of the tree with the default selection color, and "unfocused" state with a grey-ish color, similar to how Chrome Elements tab does. Even in that case, we wouldn't need a ring. But that's a future nice-to-have.