### PR TITLE
Pass Toggle label through

### DIFF
--- a/src/devtools/views/Toggle.js
+++ b/src/devtools/views/Toggle.js
@@ -18,6 +18,7 @@ export default function Toggle({
   isDisabled = false,
   isChecked,
   onChange,
+  title,
 }: Props) {
   let defaultClassName;
   if (isDisabled) {
@@ -36,7 +37,7 @@ export default function Toggle({
   );
 
   return (
-    <label className={`${defaultClassName} ${className}`}>
+    <label className={`${defaultClassName} ${className}`} title={title}>
       <input
         type="checkbox"
         className={styles.Input}


### PR DESCRIPTION
The prop was previously ignored. Now the title shows up.

<img width="269" alt="Screen Shot 2019-04-07 at 18 43 08" src="https://user-images.githubusercontent.com/810438/55687466-2fcc5500-5965-11e9-855c-9a7e8ffae36f.png">
