### PR TITLE
Move right pane loading state inside

### DIFF
--- a/src/devtools/views/Components/InspectedElementTree.js
+++ b/src/devtools/views/Components/InspectedElementTree.js
@@ -21,6 +21,7 @@ export default function InspectedElementTree({
   data,
   label,
   overrideValueFn,
+  isLoading = false,
   showWhenEmpty = false,
 }: Props) {
   const isEmpty = data === null || Object.keys(data).length === 0;
@@ -37,14 +38,17 @@ export default function InspectedElementTree({
       <div className={styles.InspectedElementTree}>
         <div className={styles.HeaderRow}>
           <div className={styles.Header}>{label}</div>
-          {!isEmpty && (
+          <div style={{ visibility: isEmpty ? 'hidden' : '' }}>
             <Button onClick={handleCopy}>
               <ButtonIcon type="copy" />
             </Button>
-          )}
+          </div>
         </div>
-        {isEmpty && <div className={styles.Empty}>None</div>}
-        {!isEmpty &&
+        {isLoading ? (
+          <div className={styles.Empty}>Loading...</div>
+        ) : isEmpty ? (
+          <div className={styles.Empty}>None</div>
+        ) : (
           Object.keys((data: any)).map(name => (
             <KeyValue
               key={name}
@@ -54,7 +58,8 @@ export default function InspectedElementTree({
               path={[name]}
               value={(data: any)[name]}
             />
-          ))}
+          ))
+        )}
       </div>
     );
   }

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -98,7 +98,17 @@ export default function SelectedElement(_: Props) {
       </div>
 
       {inspectedElement === null && (
-        <div className={styles.Loading}>Loading...</div>
+        // This is a loading state.
+        // Props always show up, so we can make selection
+        // change less janky by not hiding this section.
+        <div className={styles.InspectedElement}>
+          <InspectedElementTree
+            label="props"
+            data={null}
+            isLoading
+            showWhenEmpty
+          />
+        </div>
       )}
 
       {inspectedElement !== null && (


### PR DESCRIPTION
This might be controversial but just throwing an idea out there.

I tried https://github.com/bvaughn/react-devtools-experimental/issues/44 in https://github.com/bvaughn/react-devtools-experimental/pull/79 but I'm still not quite sure how to make it work. However, there's a potentially simpler fix we could do that I think would improve the status quo.

In the status quo, *the whole layout* jumps on selection change. In particular, a section view gets replaced with a Loading text (which doesn't exist on the normal state in this place), and then immediately gets replaced back. That makes it jarring.

![Screen Recording 2019-04-07 at 07 09 pm](https://user-images.githubusercontent.com/810438/55687843-876cbf80-5969-11e9-97bd-98b6d621cae7.gif)

I wonder if you would consider this an improvement:

![Screen Recording 2019-04-07 at 07 11 pm](https://user-images.githubusercontent.com/810438/55687860-ab300580-5969-11e9-935c-4e1d303ce982.gif)

Here, the layout itself is more static. The `props` label is always guaranteed to be there — so I don't blow it away. It might be a bit weird to see `props` written alone but after a few minutes with it, I realized I prefer it a lot to the current behavior.

Of course, in longer term figuring out https://github.com/bvaughn/react-devtools-experimental/pull/79 would be nicer but this seems like an easy opportunity to improve this IMO.