### PR TITLE
Fix spurious autoscroll

### DIFF
--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -38,12 +38,21 @@ export default function Tree(props: Props) {
   const { lineHeight } = useContext(SettingsContext);
 
   // Make sure a newly selected element is visible in the list.
-  // This is helpful for things like the owners list.
+  // This is helpful for things like the owners list and search.
   useLayoutEffect(() => {
     if (selectedElementIndex !== null && listRef.current != null) {
       listRef.current.scrollToItem(selectedElementIndex);
+      // Note this autoscroll only works for rows.
+      // There's another autoscroll inside the elements
+      // that ensures the component name is visible horizontally.
+      // It's too early to do it now because the row might not exist yet.
     }
   }, [listRef, selectedElementIndex]);
+
+  // This ref is passed down the context to elements.
+  // It lets them avoid autoscrolling to the same item many times
+  // when a selected virtual row goes in and out of the viewport.
+  const lastScrolledIDRef = useRef(null);
 
   // Navigate the tree with up/down arrow keys.
   useEffect(() => {
@@ -98,8 +107,9 @@ export default function Tree(props: Props) {
       baseDepth,
       numElements,
       getElementAtIndex,
+      lastScrolledIDRef,
     }),
-    [baseDepth, numElements, getElementAtIndex]
+    [baseDepth, numElements, getElementAtIndex, lastScrolledIDRef]
   );
 
   return (


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/67.

I'm not *super* happy with the fix because instead of overfiring, it will cause the autoscroll to underfire in some edge cases. (Such as searching for an item, scrolling away from it, and then searching for it again.) However that seems like a better tradeoff to me in the meantime than random jumps when scrolling.

We can't truly infer whether to auto-scroll or not from which virtual items are materialized, as we see from https://github.com/bvaughn/react-devtools-experimental/issues/67#issuecomment-480067969.

Another fix might be to set some flag [here](https://github.com/bvaughn/react-devtools-experimental/blob/a9c20f0b36366de81ab235cd8b3bd73fe454e513/src/devtools/views/Components/Tree.js#L44) and then reset it in the Element. However I'm not sure the order is deterministic enough — and handling all cases might turn it into a mess. Open to suggestions. 