### PR TITLE
Select DOM nodes on hover

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -63,6 +63,10 @@ export default class Agent extends EventEmitter {
     this._bridge = bridge;
 
     bridge.addListener('captureScreenshot', this.captureScreenshot);
+    bridge.addListener(
+      'clearHighlightedElementInDOM',
+      this.clearHighlightedElementInDOM
+    );
     bridge.addListener('exportProfilingSummary', this.exportProfilingSummary);
     bridge.addListener('getCommitDetails', this.getCommitDetails);
     bridge.addListener('getFiberCommits', this.getFiberCommits);
@@ -216,14 +220,22 @@ export default class Agent extends EventEmitter {
     }
   };
 
+  clearHighlightedElementInDOM = () => {
+    hideOverlay();
+  };
+
   highlightElementInDOM = ({
     displayName,
     id,
+    isSticky,
     rendererID,
+    scrollIntoView,
   }: {
     displayName: string,
     id: number,
+    isSticky: boolean,
     rendererID: number,
+    scrollIntoView: boolean,
   }) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
@@ -236,13 +248,12 @@ export default class Agent extends EventEmitter {
     }
 
     if (node != null) {
-      if (typeof node.scrollIntoView === 'function') {
+      if (scrollIntoView && typeof node.scrollIntoView === 'function') {
         // If the node isn't visible show it before highlighting it.
         // We may want to reconsider this; it might be a little disruptive.
         node.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       }
-
-      showOverlay(((node: any): HTMLElement), displayName);
+      showOverlay(((node: any): HTMLElement), displayName, isSticky);
     } else {
       hideOverlay();
     }
@@ -466,6 +477,6 @@ export default class Agent extends EventEmitter {
 
     // Don't pass the name explicitly.
     // It will be inferred from DOM tag and Fiber owner.
-    showOverlay(target);
+    showOverlay(target, null, true);
   };
 }

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -226,14 +226,14 @@ export default class Agent extends EventEmitter {
 
   highlightElementInDOM = ({
     displayName,
+    hideAfterTimeout,
     id,
-    isSticky,
     rendererID,
     scrollIntoView,
   }: {
     displayName: string,
+    hideAfterTimeout: boolean,
     id: number,
-    isSticky: boolean,
     rendererID: number,
     scrollIntoView: boolean,
   }) => {
@@ -253,7 +253,7 @@ export default class Agent extends EventEmitter {
         // We may want to reconsider this; it might be a little disruptive.
         node.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       }
-      showOverlay(((node: any): HTMLElement), displayName, isSticky);
+      showOverlay(((node: any): HTMLElement), displayName, hideAfterTimeout);
     } else {
       hideOverlay();
     }
@@ -477,6 +477,6 @@ export default class Agent extends EventEmitter {
 
     // Don't pass the name explicitly.
     // It will be inferred from DOM tag and Fiber owner.
-    showOverlay(target, null, true);
+    showOverlay(target, null, false);
   };
 }

--- a/src/backend/views/Highlighter.js
+++ b/src/backend/views/Highlighter.js
@@ -18,7 +18,8 @@ export function hideOverlay() {
 
 export function showOverlay(
   element: HTMLElement | null,
-  componentName: string = ''
+  componentName: string | null,
+  isSticky: boolean
 ) {
   if (timeoutID !== null) {
     clearTimeout(timeoutID);
@@ -34,5 +35,7 @@ export function showOverlay(
 
   overlay.inspect(element, componentName);
 
-  timeoutID = setTimeout(hideOverlay, SHOW_DURATION);
+  if (!isSticky) {
+    timeoutID = setTimeout(hideOverlay, SHOW_DURATION);
+  }
 }

--- a/src/backend/views/Highlighter.js
+++ b/src/backend/views/Highlighter.js
@@ -19,7 +19,7 @@ export function hideOverlay() {
 export function showOverlay(
   element: HTMLElement | null,
   componentName: string | null,
-  isSticky: boolean
+  hideAfterTimeout: boolean
 ) {
   if (timeoutID !== null) {
     clearTimeout(timeoutID);
@@ -35,7 +35,7 @@ export function showOverlay(
 
   overlay.inspect(element, componentName);
 
-  if (!isSticky) {
+  if (hideAfterTimeout) {
     timeoutID = setTimeout(hideOverlay, SHOW_DURATION);
   }
 }

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -87,6 +87,8 @@ export default function ElementView({ index, style, data }: Props) {
   );
 
   const rendererID = store.getRendererIDForElement(element.id) || null;
+  // Individual elements don't have a corresponding leave handler.
+  // Instead, it's implemented on the tree level.
   const handleMouseEnter = useCallback(() => {
     if (rendererID !== null) {
       bridge.send('highlightElementInDOM', {

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -86,17 +86,17 @@ export default function ElementView({ index, style, data }: Props) {
     [id, selectElementByID]
   );
 
-  const rendererID = store.getRendererIDForElement(element.id) || null;
+  const rendererID = store.getRendererIDForElement(element.id);
   // Individual elements don't have a corresponding leave handler.
   // Instead, it's implemented on the tree level.
   const handleMouseEnter = useCallback(() => {
     if (rendererID !== null) {
       bridge.send('highlightElementInDOM', {
         displayName: element.displayName,
+        hideAfterTimeout: false,
         id: element.id,
         rendererID,
         scrollIntoView: false,
-        isSticky: true,
       });
     }
   }, [bridge, element, rendererID]);

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -86,20 +86,20 @@ export default function ElementView({ index, style, data }: Props) {
     [id, selectElementByID]
   );
 
-  const rendererID = store.getRendererIDForElement(element.id);
+  const rendererID = id !== null ? store.getRendererIDForElement(id) : null;
   // Individual elements don't have a corresponding leave handler.
   // Instead, it's implemented on the tree level.
   const handleMouseEnter = useCallback(() => {
-    if (rendererID !== null) {
+    if (element !== null && id !== null && rendererID !== null) {
       bridge.send('highlightElementInDOM', {
         displayName: element.displayName,
         hideAfterTimeout: false,
-        id: element.id,
+        id,
         rendererID,
         scrollIntoView: false,
       });
     }
-  }, [bridge, element, rendererID]);
+  }, [bridge, element, id, rendererID]);
 
   // Handle elements that are removed from the tree while an async render is in progress.
   if (element == null) {

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -47,6 +47,8 @@ export default function SelectedElement(_: Props) {
           displayName: element.displayName,
           id: selectedElementID,
           rendererID,
+          scrollIntoView: true,
+          isSticky: false,
         });
       }
     }

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -45,10 +45,10 @@ export default function SelectedElement(_: Props) {
       if (rendererID !== null) {
         bridge.send('highlightElementInDOM', {
           displayName: element.displayName,
+          hideAfterTimeout: true,
           id: selectedElementID,
           rendererID,
           scrollIntoView: true,
-          isSticky: false,
         });
       }
     }
@@ -271,7 +271,7 @@ function useInspectedElement(id: number | null): InspectedElement | null {
       return () => {};
     }
 
-    const rendererID = store.getRendererIDForElement(id) || null;
+    const rendererID = store.getRendererIDForElement(id);
 
     // Update the $r variable.
     bridge.send('selectElement', { id, rendererID });

--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -12,6 +12,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList } from 'react-window';
 import { TreeContext } from './TreeContext';
 import { SettingsContext } from '../Settings/SettingsContext';
+import { BridgeContext } from '../context';
 import Element from './Element';
 import InspectHostNodesToggle from './InspectHostNodesToggle';
 import OwnersStack from './OwnersStack';
@@ -32,6 +33,7 @@ export default function Tree(props: Props) {
     selectParentElementInTree,
     selectPreviousElementInTree,
   } = useContext(TreeContext);
+  const bridge = useContext(BridgeContext);
   const listRef = useRef<FixedSizeList<any> | null>(null);
   const treeRef = useRef<HTMLDivElement | null>(null);
 
@@ -112,13 +114,17 @@ export default function Tree(props: Props) {
     [baseDepth, numElements, getElementAtIndex, lastScrolledIDRef]
   );
 
+  const handleMouseLeave = useCallback(() => {
+    bridge.send('clearHighlightedElementInDOM');
+  }, [bridge]);
+
   return (
     <div className={styles.Tree} ref={treeRef}>
       <div className={styles.SearchInput}>
         {ownerStack.length > 0 ? <OwnersStack /> : <SearchInput />}
         <InspectHostNodesToggle />
       </div>
-      <div className={styles.AutoSizerWrapper}>
+      <div className={styles.AutoSizerWrapper} onMouseLeave={handleMouseLeave}>
         <AutoSizer>
           {({ height, width }) => (
             <FixedSizeList


### PR DESCRIPTION
I know you've considered and rejected this idea before, but I'm sending in case you might reconsider.

I've been watching @threepointone struggle to use new DevTools today. Initially, he couldn't find either the "inspect from DOM" button nor the "show in DOM" button because both are small icons that are easy to miss. He was sure neither of those are implemented yet.

Even when I pointed out the toolbar buttons, he was frustrated because every time he navigated in the tree, he had to press a button to see where he was. This made navigation itself difficult because *hovering nodes to see which one he wants to select* is part of his process.

This PR is a proposal to add behavior similar to what Chrome does in Elements tab, as well as what the old DevTools did:

1. When hovering a row, we highlight the corresponding DOM node.
2. We remove the highlighting when you mouseleave the tree.

There are a few smaller changes for this to work well. For example, I added a `scrollIntoView` option (`false` for hovers) and an `isSticky` option (`true` for hovers). Scrolling on hover is too disruptive. Automatic hiding is also disruptive in hover mode because it feels like the tooltip randomly disappears. However, I kept the existing "show in DOM" behavior. It's still useful if you want to scroll to an element.

## Inspecting Unfamiliar Trees: Before

![Screen Recording 2019-04-08 at 02 33 PM](https://user-images.githubusercontent.com/810438/55728156-72486d00-5a0b-11e9-8a70-424ffd567037.gif)

## Inspecting Unfamiliar Trees: After

![Screen Recording 2019-04-08 at 02 32 PM](https://user-images.githubusercontent.com/810438/55728249-a2900b80-5a0b-11e9-9139-16a709fb1a4e.gif)

