### PR TITLE
Preserve state when switching tabs

### DIFF
--- a/shells/browser/shared/src/main.js
+++ b/shells/browser/shared/src/main.js
@@ -154,6 +154,14 @@ function createPanelIfReactLoaded() {
 
       initBridgeAndStore();
 
+      function ensureInitialHTMLIsCleared(container) {
+        if (container._hasInitialHTMLBeenCleared) {
+          return;
+        }
+        container.innerHTML = '';
+        container._hasInitialHTMLBeenCleared = true;
+      }
+
       let currentPanel = null;
 
       chrome.devtools.panels.create('⚛ Components', '', 'panel.html', panel => {
@@ -166,7 +174,7 @@ function createPanelIfReactLoaded() {
           componentsPortalContainer = panel.container;
 
           if (componentsPortalContainer != null) {
-            componentsPortalContainer.innerHTML = '';
+            ensureInitialHTMLIsCleared(componentsPortalContainer);
             render('components');
             panel.injectStyles(cloneStyleTags);
           }
@@ -188,7 +196,7 @@ function createPanelIfReactLoaded() {
           profilerPortalContainer = panel.container;
 
           if (profilerPortalContainer != null) {
-            profilerPortalContainer.innerHTML = '';
+            ensureInitialHTMLIsCleared(profilerPortalContainer);
             render('profiler');
             panel.injectStyles(cloneStyleTags);
           }
@@ -205,7 +213,7 @@ function createPanelIfReactLoaded() {
           settingsPortalContainer = panel.container;
 
           if (settingsPortalContainer != null) {
-            settingsPortalContainer.innerHTML = '';
+            ensureInitialHTMLIsCleared(settingsPortalContainer);
             render('settings');
             panel.injectStyles(cloneStyleTags);
           }

--- a/src/devtools/views/DevTools.js
+++ b/src/devtools/views/DevTools.js
@@ -107,25 +107,6 @@ export default function DevTools({
     };
   }, [store, supportsProfiling]);
 
-  let tabElement;
-  switch (tab) {
-    case 'profiler':
-      tabElement = (
-        <Profiler
-          portalContainer={profilerPortalContainer}
-          supportsProfiling={supportsProfiling}
-        />
-      );
-      break;
-    case 'settings':
-      tabElement = <Settings portalContainer={settingsPortalContainer} />;
-      break;
-    case 'components':
-    default:
-      tabElement = <Components portalContainer={componentsPortalContainer} />;
-      break;
-  }
-
   return (
     <BridgeContext.Provider value={bridge}>
       <StoreContext.Provider value={store}>
@@ -158,7 +139,21 @@ export default function DevTools({
                     />
                   </div>
                 )}
-                <div className={styles.TabContent}>{tabElement}</div>
+                <div
+                  className={styles.TabContent}
+                  hidden={tab !== 'components'}
+                >
+                  <Components portalContainer={componentsPortalContainer} />
+                </div>
+                <div className={styles.TabContent} hidden={tab !== 'profiler'}>
+                  <Profiler
+                    portalContainer={profilerPortalContainer}
+                    supportsProfiling={supportsProfiling}
+                  />
+                </div>
+                <div className={styles.TabContent} hidden={tab !== 'settings'}>
+                  <Settings portalContainer={settingsPortalContainer} />
+                </div>
               </div>
             </ProfilerContextController>
           </TreeContextController>


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/48.

At first I considered only preserving the scroll state. However on a second thought I realized I'd prefer the tree to stay there. For example if I'm in a middle of inspecting some component's props and then jump to Profiler and back, I don't want my right pane scroll to reset either. As we add more interactivity to the right pane (e.g. expanding props / nested Hooks deeper), this problem will keep coming up.

So I just keep all tabs mounted once they are. I use the `hidden` prop which in Concurrent Mode should make inactive tab updates low pri. Seems like it doesn't break anything, but we can also switch to `display: none` if it ends up being a problem.