### PR TITLE
Rename "owner stack" label to "rendered by"

### DIFF
--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -207,7 +207,7 @@ function InspectedElementView({
 
       {ownerStack.length === 0 && owners !== null && owners.length > 0 && (
         <div className={styles.Owners}>
-          <div className={styles.OwnersHeader}>owner stack</div>
+          <div className={styles.OwnersHeader}>rendered by</div>
           {owners.map(owner => (
             <OwnerView
               key={owner.id}


### PR DESCRIPTION
I think most people don't know what an "owner" is. Additionally, "stack" has unnecessary computer science connotations. Admittedly, there's a notion of "call stack" but especially beginners don't necessarily know that this is how you call the thing that you get after the error.

This wording seems a bit friendlier to me, and more immediately useful:

<img width="304" alt="Screen Shot 2019-04-08 at 3 40 22 PM" src="https://user-images.githubusercontent.com/810438/55732979-e20f2580-5a14-11e9-81c2-db9951f02692.png">

