### PR TITLE
Add a way to get props/state into console

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -75,6 +75,7 @@ export default class Agent extends EventEmitter {
     bridge.addListener('getProfilingSummary', this.getProfilingSummary);
     bridge.addListener('highlightElementInDOM', this.highlightElementInDOM);
     bridge.addListener('inspectElement', this.inspectElement);
+    bridge.addListener('logElementToConsole', this.logElementToConsole);
     bridge.addListener('overrideContext', this.overrideContext);
     bridge.addListener('overrideHookState', this.overrideHookState);
     bridge.addListener('overrideProps', this.overrideProps);
@@ -265,6 +266,15 @@ export default class Agent extends EventEmitter {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
       this._bridge.send('inspectedElement', renderer.inspectElement(id));
+    }
+  };
+
+  logElementToConsole = ({ id, rendererID }: InspectSelectParams) => {
+    const renderer = this._rendererInterfaces[rendererID];
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+    } else {
+      renderer.logElementToConsole(id);
     }
   };
 

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -1530,6 +1530,8 @@ export function attach(
       // Can view component source location.
       canViewSource,
 
+      displayName: getDataForFiber(fiber).displayName,
+
       // Inspectable properties.
       // TODO Review sanitization approach for the below inspectable values.
       context,
@@ -1558,6 +1560,43 @@ export function attach(
     result.props = cleanForBridge(result.props);
     result.state = cleanForBridge(result.state);
     return result;
+  }
+
+  function logElementToConsole(id) {
+    const result = inspectElementRaw(id);
+    if (result === null) {
+      console.warn(`Could not find Fiber with id "${id}"`);
+      return;
+    }
+
+    const supportsGroup = typeof console.groupCollapsed === 'function';
+    const label =
+      '[Click to expand] <' + (result.displayName || 'Component') + ' />';
+
+    if (supportsGroup) {
+      console.groupCollapsed(label);
+    }
+    if (result.props !== null) {
+      console.log('Props:', result.props);
+    }
+    if (result.state !== null) {
+      console.log('State:', result.state);
+    }
+    if (result.hooks !== null) {
+      console.log('Hooks:', result.hooks);
+    }
+    const nativeNode = findNativeByFiberID(id);
+    if (nativeNode !== null) {
+      console.log('Node:', nativeNode);
+    }
+    if (window.chrome || /firefox/i.test(navigator.userAgent)) {
+      console.log(
+        'Right-click any value to save it as a global variable for further inspection.'
+      );
+    }
+    if (supportsGroup) {
+      console.groupEnd();
+    }
   }
 
   function setInHook(
@@ -1870,6 +1909,7 @@ export function attach(
     handleCommitFiberRoot,
     handleCommitFiberUnmount,
     inspectElement,
+    logElementToConsole,
     prepareViewElementSource,
     overrideSuspense,
     renderer,

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -1410,7 +1410,7 @@ export function attach(
     }
   }
 
-  function inspectElement(id: number): InspectedElement | null {
+  function inspectElementRaw(id: number): InspectedElement | null {
     let fiber = idToFiberMap.get(id);
 
     if (fiber == null) {
@@ -1491,7 +1491,7 @@ export function attach(
     if (context !== null) {
       // To simplify hydration and display logic for context, wrap in a value object.
       // Otherwise simple values (e.g. strings, booleans) become harder to handle.
-      context = cleanForBridge({ value: context });
+      context = { value: context };
     }
 
     let owners = null;
@@ -1534,12 +1534,10 @@ export function attach(
       // TODO Review sanitization approach for the below inspectable values.
       context,
       hooks: usesHooks
-        ? cleanForBridge(
-            inspectHooksOfFiber(fiber, (renderer.currentDispatcherRef: any))
-          )
+        ? inspectHooksOfFiber(fiber, (renderer.currentDispatcherRef: any))
         : null,
-      props: cleanForBridge(memoizedProps),
-      state: usesHooks ? null : cleanForBridge(memoizedState),
+      props: memoizedProps,
+      state: usesHooks ? null : memoizedState,
 
       // List of owners
       owners,
@@ -1547,6 +1545,19 @@ export function attach(
       // Location of component in source coude.
       source: _debugSource,
     };
+  }
+
+  function inspectElement(id: number): InspectedElement | null {
+    let result = inspectElementRaw(id);
+    if (result === null) {
+      return null;
+    }
+    // TODO Review sanitization approach for the below inspectable values.
+    result.context = cleanForBridge(result.context);
+    result.hooks = cleanForBridge(result.hooks);
+    result.props = cleanForBridge(result.props);
+    result.state = cleanForBridge(result.state);
+    return result;
   }
 
   function setInHook(

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -106,6 +106,7 @@ export type RendererInterface = {
   handleCommitFiberRoot: (fiber: Object) => void,
   handleCommitFiberUnmount: (fiber: Object) => void,
   inspectElement: (id: number) => InspectedElement | null,
+  logElementToConsole: (id: number) => void,
   overrideSuspense: (id: number, forceFallback: boolean) => void,
   prepareViewElementSource: (id: number) => void,
   renderer: ReactRenderer | null,

--- a/src/devtools/views/ButtonIcon.js
+++ b/src/devtools/views/ButtonIcon.js
@@ -12,6 +12,7 @@ export type IconType =
   | 'export'
   | 'filter'
   | 'import'
+  | 'log-data'
   | 'more'
   | 'next'
   | 'previous'
@@ -53,6 +54,9 @@ export default function ButtonIcon({ type }: Props) {
       break;
     case 'import':
       pathData = PATH_IMPORT;
+      break;
+    case 'log-data':
+      pathData = PATH_EXPORT; // TODO: real icon
       break;
     case 'more':
       pathData = PATH_MORE;

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -39,20 +39,33 @@ export default function SelectedElement(_: Props) {
   const inspectedElement = useInspectedElement(selectedElementID);
 
   const highlightElement = useCallback(() => {
-    if (element !== null && selectedElementID !== null) {
-      const rendererID =
-        store.getRendererIDForElement(selectedElementID) || null;
+    const id = selectedElementID;
+    if (element !== null && id !== null) {
+      const rendererID = store.getRendererIDForElement(id);
       if (rendererID !== null) {
         bridge.send('highlightElementInDOM', {
           displayName: element.displayName,
           hideAfterTimeout: true,
-          id: selectedElementID,
+          id,
           rendererID,
           scrollIntoView: true,
         });
       }
     }
   }, [bridge, element, selectedElementID, store]);
+
+  const logElement = useCallback(() => {
+    const id = selectedElementID;
+    if (id !== null) {
+      const rendererID = store.getRendererIDForElement(id);
+      if (rendererID !== null) {
+        bridge.send('logElementToConsole', {
+          id,
+          rendererID,
+        });
+      }
+    }
+  }, [bridge, selectedElementID, store]);
 
   const viewSource = useCallback(() => {
     if (viewElementSource != null && selectedElementID !== null) {
@@ -88,6 +101,13 @@ export default function SelectedElement(_: Props) {
           title="Highlight this element in the page"
         >
           <ButtonIcon type="view-dom" />
+        </Button>
+        <Button
+          className={styles.IconButton}
+          onClick={logElement}
+          title="Log this component data to the console"
+        >
+          <ButtonIcon type="log-data" />
         </Button>
         <Button
           className={styles.IconButton}

--- a/src/devtools/views/Components/types.js
+++ b/src/devtools/views/Components/types.js
@@ -58,6 +58,8 @@ export type InspectedElement = {|
 
   // Location of component in source coude.
   source: Object | null,
+
+  displayName: string | null,
 |};
 
 // TODO: Add profiling type


### PR DESCRIPTION
This adds a way to dump props/state into the console for further inspection. This is to make it easier to get data "out" of DevTools — e.g. to debug a deep object, trigger a callback manually, etc.

There is `$r`, of course, but I also want to have something in the UI that's more explicit.

I built this behavior into the "view in DOM" button but we could have a separate one. I figured it doesn't hurt to unify them (especially if https://github.com/bvaughn/react-devtools-experimental/pull/92 "takes over" most use cases for regular selection) but maybe my intuition is wrong.

This PR is mostly to start the conversation. Maybe this is not very useful.

![Screen Recording 2019-04-08 at 04 27 PM](https://user-images.githubusercontent.com/810438/55736678-b2175080-5a1b-11e9-80ef-dc097c8820db.gif)
