### PR TITLE
Sync DevTools Elements and Components tabs

### DIFF
--- a/shells/browser/shared/src/main.js
+++ b/shells/browser/shared/src/main.js
@@ -184,7 +184,7 @@ function createPanelIfReactLoaded() {
             if (error) {
               console.error(error);
             } else if (didChangeSelection) {
-              bridge.send('syncSelectionFromBrowserTools');
+              bridge.send('syncSelectionFromNativeElementsPanel');
             }
           }
         );

--- a/shells/browser/shared/src/main.js
+++ b/shells/browser/shared/src/main.js
@@ -87,12 +87,8 @@ function createPanelIfReactLoaded() {
 
         // Remember if we should sync the browser DevTools to the React tab.
         // We'll only do that if user intentionally chooses a different React component.
-        let lastSelectedID = null;
-        bridge.addListener('selectElement', ({ id }) => {
-          if (!hasReactSelectionChanged && lastSelectedID !== id) {
-            hasReactSelectionChanged = true;
-            lastSelectedID = id;
-          }
+        bridge.addListener('selectElement', () => {
+          hasReactSelectionChanged = true;
         });
 
         // This flag lets us tip the Store off early that we expect to be profiling.

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -296,12 +296,19 @@ export default class Agent extends EventEmitter {
     if (renderer == null) {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
-      // Update the active DOM node on the global hook object.
-      // The content script will read this to update window.$0
-      // when we switch tabs.
+      // When a different React component is selected, we want to store
+      // the active DOM node ($0) on the global hook so that content script
+      // can update the native elements panel to match it.
       const node = ((renderer.findNativeByFiberID(id): any): HTMLElement);
       if (node !== null) {
-        window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
+        // However, we don't want to do it if the current $0 node already
+        // belongs to this component. In this case we were probably inspecting
+        // a part of its host subtree, and changing $0 would be disuptive.
+        const prev$0 = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;
+        const prev$0ID = this.getIDForNode(prev$0);
+        if (prev$0ID !== id) {
+          window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
+        }
       }
       renderer.selectElement(id);
       this._bridge.send('selectElement');

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -304,7 +304,8 @@ export default class Agent extends EventEmitter {
       if (node !== null) {
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
       }
-      this._bridge.send('selectElement', renderer.selectElement(id));
+      renderer.selectElement(id);
+      this._bridge.send('selectElement', { id });
     }
   };
 

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -304,7 +304,7 @@ export default class Agent extends EventEmitter {
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
       }
       renderer.selectElement(id);
-      this._bridge.send('selectElement', { id });
+      this._bridge.send('selectElement');
     }
   };
 

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -88,8 +88,8 @@ export default class Agent extends EventEmitter {
     bridge.addListener('stopInspectingDOM', this.stopInspectingDOM);
     bridge.addListener('stopProfiling', this.stopProfiling);
     bridge.addListener(
-      'syncSelectionFromBrowserTools',
-      this.syncSelectionFromBrowserTools
+      'syncSelectionFromNativeElementsPanel',
+      this.syncSelectionFromNativeElementsPanel
     );
     bridge.addListener('shutdown', this.shutdown);
     bridge.addListener('viewElementSource', this.viewElementSource);
@@ -299,8 +299,7 @@ export default class Agent extends EventEmitter {
       // Update the active DOM node on the global hook object.
       // The content script will read this to update window.$0
       // when we switch tabs.
-      let node: HTMLElement | null = null;
-      node = ((renderer.findNativeByFiberID(id): any): HTMLElement);
+      const node = ((renderer.findNativeByFiberID(id): any): HTMLElement);
       if (node !== null) {
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
       }
@@ -375,7 +374,7 @@ export default class Agent extends EventEmitter {
     }
   }
 
-  syncSelectionFromBrowserTools = () => {
+  syncSelectionFromNativeElementsPanel = () => {
     const target = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;
     if (target == null) {
       return;


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/59.

This implements two-way syncing between the DevTools Elements tab and the React Components tab.

I think in most cases this is what you want. Especially now that we don't show the host nodes, and so you often need to switch to Elements to play with them.

![Screen Recording 2019-04-08 at 08 47 PM](https://user-images.githubusercontent.com/810438/55752360-ad649380-5a3f-11e9-8ba2-d8817b6dfead.gif)

I'm not sure if there are any cases where the two-way binding gets in the way. Maybe we could offer an option to disable it as an escape hatch. Or maybe there's some smarter heuristic we could use.