### PR TITLE
Pressing next forces search to select

### DIFF
--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -325,14 +325,15 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
     didRequestSearch = true;
   }
   if (searchText !== prevSearchText) {
-    if (searchResults.indexOf(selectedElementID) === -1) {
+    const newSearchIndex = searchResults.indexOf(selectedElementID);
+    if (newSearchIndex === -1) {
       // Only move the selection if the new query
       // doesn't match the current selection anymore.
       didRequestSearch = true;
     } else {
       // Selected item still matches the new search query.
       // Adjust the index to reflect its position in new results.
-      searchIndex = searchResults.indexOf(selectedElementID);
+      searchIndex = newSearchIndex;
     }
   }
   if (didRequestSearch) {

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -202,17 +202,25 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
   const prevSearchText = searchText;
   const numPrevSearchResults = searchResults.length;
 
+  // We track explicitly whether search was requested because
+  // we might want to search even if search index didn't change.
+  // For example, if you press "next result" on a search with a single
+  // result but a different current selection, we'll set this to true.
+  let didRequestSearch = false;
+
   // Search isn't supported when the owner's tree is active.
   if (ownerStack.length === 0) {
     switch (type) {
       case 'GO_TO_NEXT_SEARCH_RESULT':
         if (numPrevSearchResults > 0) {
+          didRequestSearch = true;
           searchIndex =
             searchIndex + 1 < numPrevSearchResults ? searchIndex + 1 : 0;
         }
         break;
       case 'GO_TO_PREVIOUS_SEARCH_RESULT':
         if (numPrevSearchResults > 0) {
+          didRequestSearch = true;
           searchIndex =
             ((searchIndex: any): number) > 0
               ? ((searchIndex: any): number) - 1
@@ -313,10 +321,17 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
   }
 
   // Changes in search index or typing should override the selected element.
-  const didAddToSearchText =
+  if (searchIndex !== prevSearchIndex) {
+    didRequestSearch = true;
+  }
+  if (
+    // Did the user type more?
     searchText.length > prevSearchText.length &&
-    searchText.indexOf(prevSearchText) === 0;
-  if (searchIndex !== prevSearchIndex || didAddToSearchText) {
+    searchText.indexOf(prevSearchText) === 0
+  ) {
+    didRequestSearch = true;
+  }
+  if (didRequestSearch) {
     if (searchIndex === null) {
       selectedElementIndex = null;
       selectedElementID = null;

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -320,16 +320,20 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
     }
   }
 
-  // Changes in search index or typing should override the selected element.
   if (searchIndex !== prevSearchIndex) {
+    // The user intentionally navigated between search results
     didRequestSearch = true;
   }
-  if (
-    // Did the user type more?
-    searchText.length > prevSearchText.length &&
-    searchText.indexOf(prevSearchText) === 0
-  ) {
-    didRequestSearch = true;
+  if (searchText !== prevSearchText) {
+    if (searchResults.indexOf(selectedElementID) === -1) {
+      // Only move the selection if the new query
+      // doesn't match the current selection anymore.
+      didRequestSearch = true;
+    } else {
+      // Selected item still matches the new search query.
+      // Adjust the index to reflect its position in new results.
+      searchIndex = searchResults.indexOf(selectedElementID);
+    }
   }
   if (didRequestSearch) {
     if (searchIndex === null) {


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/100.

This becomes more important in light of merging https://github.com/bvaughn/react-devtools-experimental/pull/99 which might cause selection elsewhere in the tree. You want to be able to get back to your search results.

![Screen Recording 2019-04-09 at 12 05 am](https://user-images.githubusercontent.com/810438/55762583-5cfb2f00-5a5b-11e9-8661-b3528545abb5.gif)
