### PR TITLE
Make DOM selection binding one-way

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -308,22 +308,13 @@ export default class Agent extends EventEmitter {
     if (renderer == null) {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
-      // When a different React component is selected, we want to store
-      // the active DOM node ($0) on the global hook so that content script
-      // can update the native elements panel to match it.
-      const node = ((renderer.findNativeByFiberID(id): any): HTMLElement);
-      if (node !== null) {
-        // However, we don't want to do it if the current $0 node already
-        // belongs to this component. In this case we were probably inspecting
-        // a part of its host subtree, and changing $0 would be disuptive.
-        const prev$0 = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;
-        const prev$0ID = this.getIDForNode(prev$0);
-        if (prev$0ID !== id) {
-          window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
-        }
-      }
       renderer.selectElement(id);
       this._bridge.send('selectElement');
+      // TODO: If there was a way to change the selected DOM element
+      // in native Elements tab without forcing a switch to it, we'd do it here.
+      // For now, it doesn't seem like there is a way to do that:
+      // https://github.com/bvaughn/react-devtools-experimental/issues/102
+      // (Setting $0 doesn't work, and calling inspect() switches the tab.)
     }
   };
 


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/102 by making syncing one-way.

I'll talk to DevTools folks in case there's some way to restore the two-way binding later. Ideally I want a version of `inspect(foo)` that doesn't force a tab switch. Maybe they'll add it in the future.

The upside is apparently there's `chrome.devtools.panels.elements.onSelectionChanged` API that makes the other half easier. So I switched to that here too.