### PR TITLE
pointer-events: none to fix flicker on Overlay "tip"

### DIFF
--- a/src/backend/views/Overlay.js
+++ b/src/backend/views/Overlay.js
@@ -58,6 +58,7 @@ export default class Overlay {
         '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace',
       fontWeight: 'bold',
       padding: '3px 5px',
+      pointerEvents: 'none',
       position: 'fixed',
       fontSize: '12px',
     });


### PR DESCRIPTION
If click-to-inspect then hover an element in just the right place, it flickers between two elements because this "tip" element catches the hover. This should fix it.