### PR TITLE
Add collapsible icon for object and array types

### DIFF
--- a/src/devtools/views/Components/KeyValue.css
+++ b/src/devtools/views/Components/KeyValue.css
@@ -26,3 +26,13 @@
   color: var(--color-dimmer);
   font-style: italic;
 }
+
+.Opener {
+  padding: 0.125rem;
+  margin-left: -1rem;
+}
+
+.Opener svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}

--- a/src/devtools/views/Components/KeyValue.css
+++ b/src/devtools/views/Components/KeyValue.css
@@ -32,5 +32,6 @@
   display: inline-flex;
   width: 1rem;
   height: 1rem;
+  padding: 0;
   color: var(--color-expand-collapse-toggle);
 }

--- a/src/devtools/views/Components/KeyValue.css
+++ b/src/devtools/views/Components/KeyValue.css
@@ -1,5 +1,6 @@
 .Item {
   display: flex;
+  --color-expand-collapse-toggle: var(--color-dim);
 }
 
 .Name {
@@ -28,11 +29,8 @@
 }
 
 .Opener {
-  padding: 0.125rem;
-  margin-left: -1rem;
-}
-
-.Opener svg {
-  width: 0.75rem;
-  height: 0.75rem;
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-expand-collapse-toggle);
 }

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import type { Element } from 'react';
 import EditableValue from './EditableValue';
-import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import { getMetaValueLabel } from '../utils';
 import { meta } from '../../../hydration';
@@ -82,12 +81,14 @@ export default function KeyValue({
     );
   } else {
     const opener = (
-      <Button className={styles.Opener} onClick={handleToggle}>
-        <ButtonIcon type={open ? 'up' : 'down'} />
-      </Button>
+      <div className={styles.Opener} onClick={handleToggle}>
+        <ButtonIcon type={open ? 'expanded' : 'collapsed'} />
+      </div>
     );
 
     if (Array.isArray(value)) {
+      const showOpener = value.length > 0;
+
       children = open
         ? value.map((innerValue, index) => (
             <KeyValue
@@ -104,14 +105,20 @@ export default function KeyValue({
         <div
           key={`${depth}-root`}
           className={styles.Item}
-          style={{ paddingLeft }}
+          style={{
+            paddingLeft: showOpener
+              ? `calc(${paddingLeft} - 1rem)`
+              : paddingLeft,
+          }}
         >
-          {value.length > 0 && opener}
+          {showOpener && opener}
           <span className={styles.Name}>{name}</span>
           <span>Array</span>
         </div>
       );
     } else {
+      const showOpener = Object.entries(value).length > 0;
+
       children = open
         ? Object.entries(value).map<Element<any>>(([name, value]) => (
             <KeyValue
@@ -128,9 +135,13 @@ export default function KeyValue({
         <div
           key={`${depth}-root`}
           className={styles.Item}
-          style={{ paddingLeft }}
+          style={{
+            paddingLeft: showOpener
+              ? `calc(${paddingLeft} - 1rem)`
+              : paddingLeft,
+          }}
         >
-          {Object.entries(value).length > 0 && opener}
+          {showOpener && opener}
           <span className={styles.Name}>{name}</span>
           <span>Object</span>
         </div>

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { useState } from 'react';
+import type { Element } from 'react';
 import EditableValue from './EditableValue';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
@@ -112,8 +113,7 @@ export default function KeyValue({
       );
     } else {
       children = open
-        ? // $FlowFixMe "Missing type annotation for U" whatever that means
-          Object.entries(value).map(([name, value]) => (
+        ? Object.entries(value).map<Element<any>>(([name, value]) => (
             <KeyValue
               key={name}
               depth={depth + 1}

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import type { Element } from 'react';
 import EditableValue from './EditableValue';
+import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import { getMetaValueLabel } from '../utils';
 import { meta } from '../../../hydration';
@@ -81,9 +82,13 @@ export default function KeyValue({
     );
   } else {
     const opener = (
-      <div className={styles.Opener} onClick={handleToggle}>
+      <Button
+        className={styles.Opener}
+        onClick={handleToggle}
+        title={`${open ? 'Collapse' : 'Expand'} prop value`}
+      >
         <ButtonIcon type={open ? 'expanded' : 'collapsed'} />
-      </div>
+      </Button>
     );
 
     if (Array.isArray(value)) {

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -1,7 +1,9 @@
 // @flow
 
-import React from 'react';
+import React, { useState } from 'react';
 import EditableValue from './EditableValue';
+import Button from '../Button';
+import ButtonIcon from '../ButtonIcon';
 import { getMetaValueLabel } from '../utils';
 import { meta } from '../../../hydration';
 import styles from './KeyValue.css';
@@ -23,6 +25,12 @@ export default function KeyValue({
   path = [],
   value,
 }: KeyValueProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = () => {
+    setOpen(prevOpen => !prevOpen);
+  };
+
   const dataType = typeof value;
   const isSimpleType =
     dataType === 'number' ||
@@ -72,45 +80,57 @@ export default function KeyValue({
       </div>
     );
   } else {
+    const opener = (
+      <Button className={styles.Opener} onClick={handleToggle}>
+        <ButtonIcon type={open ? 'up' : 'down'} />
+      </Button>
+    );
+
     if (Array.isArray(value)) {
-      children = value.map((innerValue, index) => (
-        <KeyValue
-          key={index}
-          depth={depth + 1}
-          name={index}
-          overrideValueFn={overrideValueFn}
-          path={path.concat(index)}
-          value={value[index]}
-        />
-      ));
+      children = open
+        ? value.map((innerValue, index) => (
+            <KeyValue
+              key={index}
+              depth={depth + 1}
+              name={index}
+              overrideValueFn={overrideValueFn}
+              path={path.concat(index)}
+              value={value[index]}
+            />
+          ))
+        : [];
       children.unshift(
         <div
           key={`${depth}-root`}
           className={styles.Item}
           style={{ paddingLeft }}
         >
+          {value.length > 0 && opener}
           <span className={styles.Name}>{name}</span>
           <span>Array</span>
         </div>
       );
     } else {
-      // $FlowFixMe "Missing type annotation for U" whatever that means
-      children = Object.entries(value).map(([name, value]) => (
-        <KeyValue
-          key={name}
-          depth={depth + 1}
-          name={name}
-          overrideValueFn={overrideValueFn}
-          path={path.concat(name)}
-          value={value}
-        />
-      ));
+      children = open
+        ? // $FlowFixMe "Missing type annotation for U" whatever that means
+          Object.entries(value).map(([name, value]) => (
+            <KeyValue
+              key={name}
+              depth={depth + 1}
+              name={name}
+              overrideValueFn={overrideValueFn}
+              path={path.concat(name)}
+              value={value}
+            />
+          ))
+        : [];
       children.unshift(
         <div
           key={`${depth}-root`}
           className={styles.Item}
           style={{ paddingLeft }}
         >
+          {Object.entries(value).length > 0 && opener}
           <span className={styles.Name}>{name}</span>
           <span>Object</span>
         </div>


### PR DESCRIPTION
I've got it working, but the arrow is kinda small on comfortable mode, maybe I shouldn't be using the `ButtonIcon` here?

![inspect-collapse](https://user-images.githubusercontent.com/10223856/55767707-6af78280-5a50-11e9-81a1-a27d6b48ed5a.gif)

This is comfortable mode:

![image](https://user-images.githubusercontent.com/10223856/55767666-47ccd300-5a50-11e9-8a5d-a9edda0a09a2.png)