### PR TITLE
Put DevTools in dev shell above the inspector

### DIFF
--- a/shells/dev/index.html
+++ b/shells/dev/index.html
@@ -13,6 +13,7 @@
         height: 400px;
         max-height: 50%;
         overflow: hidden;
+        z-index: 10000001;
       }
       body {
         display: flex;


### PR DESCRIPTION
Kinda hacky but this makes testing in browser shell easier because you don't see the overlay all the time.