### PR TITLE
Ignore hover when navigating with keyboard

### DIFF
--- a/src/devtools/views/Components/Element.css
+++ b/src/devtools/views/Components/Element.css
@@ -1,6 +1,7 @@
 .Element,
 .InactiveSelectedElement,
-.SelectedElement {
+.SelectedElement,
+.HoveredElement {
   border-radius: 0.25em;
   white-space: nowrap;
   line-height: var(--line-height-data);
@@ -11,7 +12,7 @@
 
   --color-expand-collapse-toggle: var(--color-dim);
 }
-.Element:hover {
+.HoveredElement {
   background-color: var(--color-hover-background);
 }
 .InactiveSelectedElement {

--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -27,7 +27,9 @@ export type ItemData = {|
   baseDepth: number,
   numElements: number,
   getElementAtIndex: (index: number) => Element | null,
+  isNavigatingWithKeyboard: boolean,
   lastScrolledIDRef: { current: number | null },
+  onElementMouseEnter: (id: number) => void,
   treeFocused: boolean,
 |};
 
@@ -49,6 +51,9 @@ export default function Tree(props: Props) {
   } = useContext(TreeContext);
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
+  const [isNavigatingWithKeyboard, setIsNavigatingWithKeyboard] = useState(
+    false
+  );
   // $FlowFixMe https://github.com/facebook/flow/issues/7341
   const listRef = useRef<FixedSizeList<ItemData> | null>(null);
   const treeRef = useRef<HTMLDivElement | null>(null);
@@ -100,8 +105,6 @@ export default function Tree(props: Props) {
       }
 
       let element;
-
-      // eslint-disable-next-line default-case
       switch (event.key) {
         case 'ArrowDown':
           event.preventDefault();
@@ -143,7 +146,10 @@ export default function Tree(props: Props) {
           event.preventDefault();
           selectPreviousElementInTree();
           break;
+        default:
+          return;
       }
+      setIsNavigatingWithKeyboard(true);
     };
 
     // It's important to listen to the ownerDocument to support the browser extension.
@@ -163,8 +169,8 @@ export default function Tree(props: Props) {
     store,
   ]);
 
+  // Focus management.
   const handleBlur = useCallback(() => setTreeFocused(false));
-
   const handleFocus = useCallback(() => {
     setTreeFocused(true);
 
@@ -189,6 +195,53 @@ export default function Tree(props: Props) {
     [selectedElementID, selectOwner]
   );
 
+  const highlightElementInDOM = useCallback(
+    (id: number) => {
+      const element = store.getElementByID(id);
+      const rendererID = store.getRendererIDForElement(id);
+      if (element !== null) {
+        bridge.send('highlightElementInDOM', {
+          displayName: element.displayName,
+          hideAfterTimeout: false,
+          id,
+          rendererID,
+          scrollIntoView: false,
+        });
+      }
+    },
+    [store, bridge]
+  );
+
+  // If we switch the selected element while using the keyboard,
+  // start highlighting it in the DOM instead of the last hovered node.
+  useEffect(() => {
+    if (isNavigatingWithKeyboard && selectedElementID !== null) {
+      highlightElementInDOM(selectedElementID);
+    }
+  }, [isNavigatingWithKeyboard, highlightElementInDOM, selectedElementID]);
+
+  // Highlight last hovered element.
+  const handleElementMouseEnter = useCallback(
+    id => {
+      // Ignore hover while we're navigating with keyboard.
+      // This avoids flicker from the hovered nodes under the mouse.
+      if (!isNavigatingWithKeyboard) {
+        highlightElementInDOM(id);
+      }
+    },
+    [isNavigatingWithKeyboard, highlightElementInDOM]
+  );
+
+  const handleMouseMove = useCallback(() => {
+    // We started using the mouse again.
+    // This will enable hover styles in individual rows.
+    setIsNavigatingWithKeyboard(false);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    bridge.send('clearHighlightedElementInDOM');
+  }, [bridge]);
+
   // Let react-window know to re-render any time the underlying tree data changes.
   // This includes the owner context, since it controls a filtered view of the tree.
   const itemData = useMemo<ItemData>(
@@ -196,15 +249,21 @@ export default function Tree(props: Props) {
       baseDepth,
       numElements,
       getElementAtIndex,
+      isNavigatingWithKeyboard,
+      onElementMouseEnter: handleElementMouseEnter,
       lastScrolledIDRef,
       treeFocused,
     }),
-    [baseDepth, numElements, getElementAtIndex, lastScrolledIDRef, treeFocused]
+    [
+      baseDepth,
+      numElements,
+      getElementAtIndex,
+      isNavigatingWithKeyboard,
+      handleElementMouseEnter,
+      lastScrolledIDRef,
+      treeFocused,
+    ]
   );
-
-  const handleMouseLeave = useCallback(() => {
-    bridge.send('clearHighlightedElementInDOM');
-  }, [bridge]);
 
   return (
     <div className={styles.Tree} ref={treeRef}>
@@ -217,6 +276,7 @@ export default function Tree(props: Props) {
         onBlur={handleBlur}
         onFocus={handleFocus}
         onKeyPress={handleKeyPress}
+        onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         ref={focusTargetRef}
         tabIndex={0}


### PR DESCRIPTION
This cleans up the selection/hover behavior when using the keyboard.
Two main changes:

* Hover while we're using the keyboard navigation is hidden. It reappears on mousemove.
* When we're using the keyboard, the DOM selection follows the selected item.

This matches Chrome behavior. (Except that Chrome also keeps last hovered item *always* visible but doesn't update it during keyboard nav — which I think is actually worse than what this PR does.)

![Screen Recording 2019-04-10 at 08 22 PM](https://user-images.githubusercontent.com/810438/55907499-dc5d3f80-5bce-11e9-8d8c-58f98ae3fa5a.gif)
