### PR TITLE
Fix fiber info sidepanel not scrollable

### DIFF
--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
@@ -10,6 +10,7 @@
   padding: 0.5rem;
   user-select: none;
   border-top: 1px solid var(--color-border);
+  overflow-y: auto;
 }
 
 .Component {


### PR DESCRIPTION
You couldn't scroll when the fiber commits exceeded the amount it could fit on the panel.