### PR TITLE
Track search navigation in DOM

### DIFF
--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -44,7 +44,7 @@ export default function ElementView({ data, index, style }: Props) {
   const {
     lastScrolledIDRef,
     treeFocused,
-    isNavigatingWithKeyboard,
+    isUsingKeyboardOrSearch,
     onElementMouseEnter,
   } = data;
   const id = element === null ? null : element.id;
@@ -122,7 +122,7 @@ export default function ElementView({ data, index, style }: Props) {
     className = treeFocused
       ? styles.SelectedElement
       : styles.InactiveSelectedElement;
-  } else if (isHovered && !isNavigatingWithKeyboard) {
+  } else if (isHovered && !isUsingKeyboardOrSearch) {
     className = styles.HoveredElement;
   }
 

--- a/src/devtools/views/Components/SearchInput.js
+++ b/src/devtools/views/Components/SearchInput.js
@@ -8,9 +8,12 @@ import Icon from '../Icon';
 
 import styles from './SearchInput.css';
 
-type Props = {||};
+type Props = {|
+  onSearchInteraction: () => void,
+|};
 
 export default function SearchInput(props: Props) {
+  const { onSearchInteraction } = props;
   const {
     goToNextSearchResult,
     goToPreviousSearchResult,
@@ -25,13 +28,17 @@ export default function SearchInput(props: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleTextChange = useCallback(
-    ({ currentTarget }) => setSearchText(currentTarget.value),
-    [setSearchText]
+    ({ currentTarget }) => {
+      setSearchText(currentTarget.value);
+      onSearchInteraction();
+    },
+    [setSearchText, onSearchInteraction]
   );
 
   const resetSearch = useCallback(() => {
     setSearchText('');
-  }, [setSearchText]);
+    onSearchInteraction();
+  }, [setSearchText, onSearchInteraction]);
 
   const handleKeyDown = useCallback(
     event => {
@@ -39,26 +46,29 @@ export default function SearchInput(props: Props) {
       switch (event.key) {
         case 'ArrowDown':
           selectNextElementInTree();
+          onSearchInteraction();
           event.preventDefault();
           break;
         case 'ArrowUp':
           selectPreviousElementInTree();
+          onSearchInteraction();
           event.preventDefault();
           break;
         default:
           break;
       }
     },
-    [selectNextElementInTree, selectPreviousElementInTree]
+    [selectNextElementInTree, selectPreviousElementInTree, onSearchInteraction]
   );
 
   const handleInputKeyPress = useCallback(
     ({ key }) => {
       if (key === 'Enter') {
         goToNextSearchResult();
+        onSearchInteraction();
       }
     },
-    [goToNextSearchResult]
+    [goToNextSearchResult, onSearchInteraction]
   );
 
   // Auto-focus search input
@@ -109,7 +119,10 @@ export default function SearchInput(props: Props) {
       <Button
         className={styles.IconButton}
         disabled={!searchText}
-        onClick={goToPreviousSearchResult}
+        onClick={() => {
+          goToPreviousSearchResult();
+          onSearchInteraction();
+        }}
         title="Scroll to previous search result"
       >
         <ButtonIcon type="up" />
@@ -117,7 +130,10 @@ export default function SearchInput(props: Props) {
       <Button
         className={styles.IconButton}
         disabled={!searchText}
-        onClick={goToNextSearchResult}
+        onClick={() => {
+          goToNextSearchResult();
+          onSearchInteraction();
+        }}
         title="Scroll to next search result"
       >
         <ButtonIcon type="down" />


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/139.

This makes it significantly easier to understand what the search matches represent on the screen. E.g. you can search for a Relay container internally, press Enter many times and quickly see different parts highlight.

It reuses the mechanism I introduced in https://github.com/bvaughn/react-devtools-experimental/pull/126. If you navigate the tree via something else than scrolling (keyboard or search) then we want to hide hover and to start highlighting the DOM components in response to those changes.

If you're super concerned about this component growing, I can try to pull it out into a custom Hook.

![Screen Recording 2019-04-12 at 06 58 PM](https://user-images.githubusercontent.com/810438/56056852-41db3880-5d55-11e9-90a8-a57d2d4c00a8.gif)

![Screen Recording 2019-04-12 at 07 05 PM](https://user-images.githubusercontent.com/810438/56057155-0db44780-5d56-11e9-88a8-263f0d509e24.gif)
