### PR TITLE
Polish some mouse interactions

### DIFF
--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -190,6 +190,11 @@ function ExpandCollapseToggle({ element, store }: ExpandCollapseToggleProps) {
     [id, isCollapsed, store]
   );
 
+  const stopPropagation = useCallback(event => {
+    // Prevent the row from selecting
+    event.stopPropagation();
+  }, []);
+
   if (children.length === 0) {
     return <div className={styles.ExpandCollapseToggle} />;
   }
@@ -197,6 +202,7 @@ function ExpandCollapseToggle({ element, store }: ExpandCollapseToggleProps) {
   return (
     <div
       className={styles.ExpandCollapseToggle}
+      onMouseDown={stopPropagation}
       onClick={toggleCollapsed}
       onDoubleClick={swallowDoubleClick}
     >

--- a/src/devtools/views/Components/HooksTree.js
+++ b/src/devtools/views/Components/HooksTree.js
@@ -130,7 +130,7 @@ function HookView({ canEditHooks, hook, id, path = [] }: HookViewProps) {
         <div className={styles.Hook}>
           <div className={styles.NameValueRow}>
             <ExpandCollapseToggle isOpen={isOpen} setIsOpen={setIsOpen} />
-            <span onDoubleClick={toggleIsOpen} className={styles.Name}>
+            <span onClick={toggleIsOpen} className={styles.Name}>
               {name}
             </span>
           </div>
@@ -149,7 +149,7 @@ function HookView({ canEditHooks, hook, id, path = [] }: HookViewProps) {
         <div className={styles.Hook}>
           <div className={styles.NameValueRow}>
             <ExpandCollapseToggle isOpen={isOpen} setIsOpen={setIsOpen} />
-            <span onDoubleClick={toggleIsOpen} className={styles.Name}>
+            <span onClick={toggleIsOpen} className={styles.Name}>
               {name}
             </span>{' '}
             {/* $FlowFixMe */}

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -115,7 +115,7 @@ export default function KeyValue({
           )}
           <span
             className={styles.Name}
-            onDoubleClick={hasChildren ? toggleIsOpen : undefined}
+            onClick={hasChildren ? toggleIsOpen : undefined}
           >
             {name}
           </span>
@@ -150,7 +150,7 @@ export default function KeyValue({
           )}
           <span
             className={styles.Name}
-            onDoubleClick={hasChildren ? toggleIsOpen : undefined}
+            onClick={hasChildren ? toggleIsOpen : undefined}
           >
             {name}
           </span>


### PR DESCRIPTION
- Clicking expand/collapse arrow no longer selects the node. This matches Chrome behavior and ensures you can hide components with annoyingly jumpy children if you want without losing where you were in the tree.

- Also fixes https://github.com/bvaughn/react-devtools-experimental/issues/144 — a single click now expands the object properties, similar to how you normally inspect objects in the console.