### PR TITLE
Consistently scroll component name into view

### DIFF
--- a/src/devtools/views/Components/Element.css
+++ b/src/devtools/views/Components/Element.css
@@ -17,6 +17,11 @@
   background-color: var(--color-inactive-background);
 }
 
+.ScrollAnchor {
+  height: 100%;
+  width: 0;
+}
+
 .SelectedElement {
   background-color: var(--color-selected-background);
   color: var(--color-selected-foreground);

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -80,15 +80,17 @@ export default function ElementView({ data, index, style }: Props) {
       // However, even calling scrollIntoView() on their parent node
       // wouldn't guarantee that it will be *fully* brought into view.
       // As a workaround, we'll have two anchor spans, and scroll each into view.
-      if (scrollAnchorStartRef.current !== null) {
-        scrollAnchorStartRef.current.scrollIntoView({
+      if (scrollAnchorEndRef.current !== null) {
+        scrollAnchorEndRef.current.scrollIntoView({
           behavior: 'auto',
           block: 'nearest',
           inline: 'nearest',
         });
       }
-      if (scrollAnchorEndRef.current !== null) {
-        scrollAnchorEndRef.current.scrollIntoView({
+      if (scrollAnchorStartRef.current !== null) {
+        // We scroll the start anchor last because it's
+        // more important for it to be in the view.
+        scrollAnchorStartRef.current.scrollIntoView({
           behavior: 'auto',
           block: 'nearest',
           inline: 'nearest',

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -56,7 +56,8 @@ export default function ElementView({ data, index, style }: Props) {
     }
   }, [id, selectOwner]);
 
-  const ref = useRef<HTMLSpanElement | null>(null);
+  const scrollAnchorStartRef = useRef<HTMLSpanElement | null>(null);
+  const scrollAnchorEndRef = useRef<HTMLSpanElement | null>(null);
 
   // The tree above has its own autoscrolling, but it only works for rows.
   // However, even when the row gets into the viewport, the component name
@@ -74,8 +75,20 @@ export default function ElementView({ data, index, style }: Props) {
       }
       lastScrolledIDRef.current = id;
 
-      if (ref.current !== null) {
-        ref.current.scrollIntoView({
+      // We want to bring the whole <Component> name into view,
+      // including the expansion toggle and the "=== $r" hint.
+      // However, even calling scrollIntoView() on their parent node
+      // wouldn't guarantee that it will be *fully* brought into view.
+      // As a workaround, we'll have two anchor spans, and scroll each into view.
+      if (scrollAnchorStartRef.current !== null) {
+        scrollAnchorStartRef.current.scrollIntoView({
+          behavior: 'auto',
+          block: 'nearest',
+          inline: 'nearest',
+        });
+      }
+      if (scrollAnchorEndRef.current !== null) {
+        scrollAnchorEndRef.current.scrollIntoView({
           behavior: 'auto',
           block: 'nearest',
           inline: 'nearest',
@@ -149,10 +162,11 @@ export default function ElementView({ data, index, style }: Props) {
         marginBottom: `-${style.height}px`,
       }}
     >
+      <span className={styles.ScrollAnchor} ref={scrollAnchorStartRef} />
       {ownerStack.length === 0 ? (
         <ExpandCollapseToggle element={element} store={store} />
       ) : null}
-      <span className={styles.Component} ref={ref}>
+      <span className={styles.Component}>
         <DisplayName displayName={displayName} id={((id: any): number)} />
         {key && (
           <Fragment>
@@ -162,6 +176,7 @@ export default function ElementView({ data, index, style }: Props) {
         )}
       </span>
       {showDollarR && <span className={styles.DollarR}>&nbsp;== $r</span>}
+      <span className={styles.ScrollAnchor} ref={scrollAnchorEndRef} />
     </div>
   );
 }

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -77,7 +77,7 @@ export default function ElementView({ data, index, style }: Props) {
 
       // We want to bring the whole <Component> name into view,
       // including the expansion toggle and the "=== $r" hint.
-      // However, even calling scrollIntoView() on their parent node
+      // However, even calling scrollIntoView() on a wrapper parent node (e.g. <span>)
       // wouldn't guarantee that it will be *fully* brought into view.
       // As a workaround, we'll have two anchor spans, and scroll each into view.
       if (scrollAnchorEndRef.current !== null) {


### PR DESCRIPTION
This has been bugging me for the last two weeks. I thought there's no good fix but this one works.

## Before

![Screen Recording 2019-04-13 at 01 59 am](https://user-images.githubusercontent.com/810438/56072542-188bce00-5d90-11e9-84c7-0805ffc7bd6e.gif)

## After

![Screen Recording 2019-04-13 at 01 59 am (1)](https://user-images.githubusercontent.com/810438/56072547-22adcc80-5d90-11e9-913e-78c5fadc7f9f.gif)

## What Else?

This also fixes https://github.com/bvaughn/react-devtools-experimental/issues/142. You can try it by inspecting FB trees with "find by DOM node". Previously, it would occasionally fail to fully display the whole component name. Now it always does.