### PR TITLE
Don't reset selected item on search mismatch or exit

### DIFF
--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -369,16 +369,11 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
       searchIndex = newSearchIndex;
     }
   }
-  if (didRequestSearch) {
-    if (searchIndex === null) {
-      selectedElementIndex = null;
-      selectedElementID = null;
-    } else {
-      selectedElementID = ((searchResults[searchIndex]: any): number);
-      selectedElementIndex = store.getIndexOfElementID(
-        ((selectedElementID: any): number)
-      );
-    }
+  if (didRequestSearch && searchIndex !== null) {
+    selectedElementID = ((searchResults[searchIndex]: any): number);
+    selectedElementIndex = store.getIndexOfElementID(
+      ((selectedElementID: any): number)
+    );
   }
 
   return {


### PR DESCRIPTION
When I exit the search mode, this keeps the last selected item. There's no use resetting it — and usually I want to continue from that point on.

Similarly, if the search no longer matches, this keeps the last selected item. I don't think resetting it does any good. On the opposite, it often leads to me pressing "down" and accidentally ending up on the very top of the tree.

![Screen Recording 2019-04-13 at 04 18 pm](https://user-images.githubusercontent.com/810438/56081733-6a703a80-5e08-11e9-985c-c6ec567edd5d.gif)
