### PR TITLE
Remove broken padding from Tree

### DIFF
--- a/src/devtools/views/Components/Tree.css
+++ b/src/devtools/views/Components/Tree.css
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   border-top: 1px solid var(--color-border);
-  padding: 0.25rem;
 }
 
 .SearchInput {


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/143.

It kinda made sense when we had a focus ring but I don't think it's desirable to have anymore either.

## Before

<img width="857" alt="Screen Shot 2019-04-13 at 16 55 48" src="https://user-images.githubusercontent.com/810438/56082171-6abf0480-5e0d-11e9-8bed-61e69bd5b5be.png">

## After

<img width="858" alt="Screen Shot 2019-04-13 at 16 57 56" src="https://user-images.githubusercontent.com/810438/56082174-73afd600-5e0d-11e9-9a64-f4aa6ab3a711.png">
