### PR TITLE
View DOM button opens Elements tab

### DIFF
--- a/shells/browser/shared/src/main.js
+++ b/shells/browser/shared/src/main.js
@@ -84,6 +84,9 @@ function createPanelIfReactLoaded() {
             response => bridge.send('screenshotCaptured', response)
           );
         });
+        bridge.addListener('syncSelectionToNativeElementsPanel', () => {
+          setBrowserSelectionFromReact();
+        });
 
         // This flag lets us tip the Store off early that we expect to be profiling.
         // This avoids flashing a temporary "Profiling not supported" message in the Profiler tab,
@@ -160,6 +163,22 @@ function createPanelIfReactLoaded() {
         }
         container.innerHTML = '';
         container._hasInitialHTMLBeenCleared = true;
+      }
+
+      function setBrowserSelectionFromReact() {
+        // This is currently only called on demand when you press "view DOM".
+        // In the future, if Chrome adds an inspect() that doesn't switch tabs,
+        // we could make this happen automatically when you select another component.
+        chrome.devtools.inspectedWindow.eval(
+          '(window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 !== $0) ?' +
+            '(inspect(window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0), true) :' +
+            'false',
+          (didSelectionChange, error) => {
+            if (error) {
+              console.error(error);
+            }
+          }
+        );
       }
 
       function setReactSelectionFromBrowser() {

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -235,12 +235,14 @@ export default class Agent extends EventEmitter {
     displayName,
     hideAfterTimeout,
     id,
+    openNativeElementsPanel,
     rendererID,
     scrollIntoView,
   }: {
     displayName: string,
     hideAfterTimeout: boolean,
     id: number,
+    openNativeElementsPanel: boolean,
     rendererID: number,
     scrollIntoView: boolean,
   }) => {
@@ -261,6 +263,10 @@ export default class Agent extends EventEmitter {
         node.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       }
       showOverlay(((node: any): HTMLElement), displayName, hideAfterTimeout);
+      if (openNativeElementsPanel) {
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
+        this._bridge.send('syncSelectionToNativeElementsPanel');
+      }
     } else {
       hideOverlay();
     }

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -46,6 +46,7 @@ export default function SelectedElement(_: Props) {
           displayName: element.displayName,
           hideAfterTimeout: true,
           id: selectedElementID,
+          openNativeElementsPanel: true,
           rendererID,
           scrollIntoView: true,
         });
@@ -96,7 +97,7 @@ export default function SelectedElement(_: Props) {
         <Button
           className={styles.IconButton}
           onClick={highlightElement}
-          title="Highlight this element in the page"
+          title="Inspect the matching DOM element"
         >
           <ButtonIcon type="view-dom" />
         </Button>

--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -204,6 +204,7 @@ export default function Tree(props: Props) {
           displayName: element.displayName,
           hideAfterTimeout: false,
           id,
+          openNativeElementsPanel: false,
           rendererID,
           scrollIntoView: false,
         });


### PR DESCRIPTION
I haven't found much use for "view in DOM" since now we highlight on hover and keyboard navigation. However, I *do* often wish to switch to the corresponding DOM node when debugging styles and layout. Unfortunately, we don't have a two-way binding yet.

Let's solve these problems together. I'm making the "view in DOM" button open up the Elements tab *in addition* to highlighting the DOM node. This makes it more useful and fills in the missing functionality.

![Screen Recording 2019-04-13 at 06 54 pm](https://user-images.githubusercontent.com/810438/56083523-08bacb00-5e1e-11e9-9492-3872d35a8e43.gif)
