### PR TITLE
Add a stress test for tree traversal

### DIFF
--- a/src/__tests__/__snapshots__/store-test.js.snap
+++ b/src/__tests__/__snapshots__/store-test.js.snap
@@ -25,6 +25,27 @@ exports[`Store should filter DOM nodes from the store tree: 1: mount 1`] = `
         <Child>
 `;
 
+exports[`Store should handle a stress test with different tree operations: 1: abcde 1`] = `
+[root]
+  ▾ <Parent>
+      <A key="a">
+      <B key="b">
+      <C key="c">
+      <D key="d">
+      <E key="e">
+`;
+
+exports[`Store should handle a stress test with different tree operations: 2: abxde 1`] = `
+[root]
+  ▾ <Parent>
+      <A key="a">
+      <B key="b">
+    ▾ <C key="c">
+        <X>
+      <D key="d">
+      <E key="e">
+`;
+
 exports[`Store should support collapsing parts of the tree: 1: mount 1`] = `
 [root]
   ▾ <Grandparent>


### PR DESCRIPTION
This adds a stress-test for the tree traversal logic. In particular, it stresses correct handling for mounting, updating, unmounting, and re-ordering elements.

There are only two snapshots for two "ideal" states. The rest of the test is taking different alternative trees which are known to produce the same DOM output, and verifying that the DevTools output also matches these known snapshots.

For each alternative tree, we test that:

* Mounting it produces the desired result
* Updating from previous tree to it _also_ produces the desired result, both in Sync and Concurrent Modes

See inline comments for more details.

It's nice to know that this passes.