### PR TITLE
Add Suspense stress test

### DIFF
--- a/src/__tests__/__snapshots__/store-test.js.snap
+++ b/src/__tests__/__snapshots__/store-test.js.snap
@@ -25,6 +25,121 @@ exports[`Store should filter DOM nodes from the store tree: 1: mount 1`] = `
         <Child>
 `;
 
+exports[`Store should handle a stress test for Suspense 1`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 2`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 3`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+        <B key="b">
+        <C key="c">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 4`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <B key="b">
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 5`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 6`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 7`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 8`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+        <B key="b">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 9`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 10`] = `
+[root]
+  ▾ <Root>
+      <X>
+      <Suspense>
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 11`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <B key="b">
+      <Y>
+`;
+
+exports[`Store should handle a stress test for Suspense 12`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+      <Y>
+`;
+
 exports[`Store should handle a stress test with different tree operations: 1: abcde 1`] = `
 [root]
   ▾ <Parent>

--- a/src/__tests__/setupTests.js
+++ b/src/__tests__/setupTests.js
@@ -33,6 +33,7 @@ env.beforeEach(() => {
 
   initBackend(global.__REACT_DEVTOOLS_GLOBAL_HOOK__, agent, global);
 
+  global.bridge = bridge;
   global.store = new Store(bridge);
 });
 env.afterEach(() => {


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/111. This is not a fuzzer but it's close enough and might be sufficient.

Parts of this test are commented out. As far as I can tell, the test itself is fine, but those parts don't pass due to actual bugs in the Suspense logic discovered by the test. I'll be looking into fixing them tomorrow. That doesn't block merging this though.

Follow-ups:

* Fix Suspense logic
* Test Concurrent Mode
* Test setStates inside Suspense