### PR TITLE
Improve contrast for light mode

### DIFF
--- a/src/devtools/views/Settings/SettingsContext.js
+++ b/src/devtools/views/Settings/SettingsContext.js
@@ -247,6 +247,9 @@ function updateThemeVariables(
   updateStyleHelper(theme, 'color-search-match', documentElements);
   updateStyleHelper(theme, 'color-search-match-current', documentElements);
   updateStyleHelper(theme, 'color-text-color', documentElements);
+
+  // Font smoothing varies based on the theme.
+  updateStyleHelper(theme, 'font-smoothing', documentElements);
 }
 
 export { SettingsContext, SettingsContextController };

--- a/src/devtools/views/root.css
+++ b/src/devtools/views/root.css
@@ -28,7 +28,7 @@
   --light-color-commit-gradient-8: #efbb49;
   --light-color-commit-gradient-9: #febc38;
   --light-color-commit-gradient-text: #000000;
-  --light-color-component-name: #8155cb;
+  --light-color-component-name: #6a51b2;
   --light-color-component-name-inverted: #ffffff;
   --light-color-dim: #777d88;
   --light-color-dimmer: #cfd1d5;
@@ -95,6 +95,11 @@
   --dark-color-selected-foreground: #ffffff;
   --dark-color-text-color: #ffffff;
 
+  /* Font smoothing */
+  --light-font-smoothing: auto;
+  --dark-font-smoothing: antialiased;
+  --font-smoothing: auto;
+
   /* Compact density */
   --compact-font-size-monospace-small: 9px;
   --compact-font-size-monospace-normal: 11px;
@@ -127,5 +132,5 @@
 * {
   box-sizing: border-box;
 
-  -webkit-font-smoothing: antialiased;
+  -webkit-font-smoothing: var(--font-smoothing);
 }


### PR DESCRIPTION
# Light mode
* Darkened component name color slightly
* Removed anti-aliasing
## Before
![Screen Shot 2019-04-17 at 11 39 17 AM](https://user-images.githubusercontent.com/29597/56312764-c2a78500-6105-11e9-8595-d74e44012efc.png)

## After
![Screen Shot 2019-04-17 at 11 39 21 AM](https://user-images.githubusercontent.com/29597/56312774-c509df00-6105-11e9-90a2-8c0cf904c4a1.png)

# Dark mode
* No changes
## Before
![Screen Shot 2019-04-17 at 11 39 29 AM](https://user-images.githubusercontent.com/29597/56312783-c804cf80-6105-11e9-939e-dcdbb2050f3c.png)

## After
![Screen Shot 2019-04-17 at 11 39 32 AM](https://user-images.githubusercontent.com/29597/56312787-ca672980-6105-11e9-9f69-68d8a3163eb2.png)
