### PR TITLE
Select tab when the mouse is pressed

### DIFF
--- a/src/devtools/views/TabBar.js
+++ b/src/devtools/views/TabBar.js
@@ -68,6 +68,7 @@ export default function TabBar({
           )}
           key={id}
           onKeyDown={handleKeyDown}
+          onMouseDown={() => selectTab(id)}
           title={title || label}
         >
           <input


### PR DESCRIPTION
Selecting the tab when the mouse is pressed rather than only when it is
released makes tab switching feel faster and also matches how the Chrome dev
tools behave.

The previous tab selection handler which listens for the radio button's
selection has been kept for the benefit of interaction methods which
don't trigger the mousedown handler.