### PR TITLE
Assert removal happens in the right order

### DIFF
--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -752,13 +752,13 @@ export function attach(
       nextOperation[1] = id;
       endNextOperation(false);
     } else if (!shouldFilterFiber(fiber)) {
-      // Non-root fibers are deleted during the commit phase.
-      // They are deleted in the child-first order. However
-      // DevTools currently expects deletions to be parent-first.
-      // This is why we unshift deletions rather tha
       beginNextOperation(2);
       nextOperation[0] = TREE_OPERATION_REMOVE;
       nextOperation[1] = id;
+      // Non-root fibers are deleted during the commit phase.
+      // They are deleted in the parent-first order. However
+      // DevTools currently expects deletions to be child-first.
+      // This is why we prepend the delete operation to the queue.
       endNextOperation(true);
     }
     fiberToIDMap.delete(primaryFiber);

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -760,8 +760,7 @@ export default class Store extends EventEmitter {
 
           this._idToElement.delete(id);
 
-          parentElement = ((this._idToElement.get(parentID): any): Element);
-          if (parentElement == null) {
+          if (parentID === 0) {
             if (__DEBUG__) {
               debug('Remove', `fiber ${id} root`);
             }
@@ -775,7 +774,15 @@ export default class Store extends EventEmitter {
             if (__DEBUG__) {
               debug('Remove', `fiber ${id} from parent ${parentID}`);
             }
-
+            parentElement = ((this._idToElement.get(parentID): any): Element);
+            if (parentElement === undefined) {
+              throw new Error(
+                'Fiber ' +
+                  id +
+                  ' was removed after its parent. ' +
+                  'This is a bug in React DevTools.'
+              );
+            }
             parentElement.children = parentElement.children.filter(
               childID => childID !== id
             );


### PR DESCRIPTION
I just spent about an hour chasing bug that was caused by wrong deletion order (the bug was in some new code, not in master).

I was misled by the comment which claims deletions are reported by React in the child-first order — whereas the opposite is true. I've fixed the comment and added an assertion that ensures this is actually the case.