### PR TITLE
Fail tests on errors in renderer

### DIFF
--- a/src/__tests__/setupTests.js
+++ b/src/__tests__/setupTests.js
@@ -16,6 +16,7 @@ env.beforeEach(() => {
   jest.useFakeTimers();
 
   const originalConsoleError = console.error;
+  // $FlowFixMe
   console.error = (...args) => {
     if (args[0] === 'Warning: React DevTools encountered an error: %s') {
       // Rethrow errors from React.

--- a/src/__tests__/setupTests.js
+++ b/src/__tests__/setupTests.js
@@ -15,6 +15,15 @@ env.beforeEach(() => {
   // Fake timers let us flush Bridge operations between setup and assertions.
   jest.useFakeTimers();
 
+  const originalConsoleError = console.error;
+  console.error = (...args) => {
+    if (args[0] === 'Warning: React DevTools encountered an error: %s') {
+      // Rethrow errors from React.
+      throw args[1];
+    }
+    originalConsoleError.apply(console, args);
+  };
+
   installHook(global);
 
   const bridgeListeners = [];


### PR DESCRIPTION
React catches errors in DevTools renderer hooks. However, this means they don't fail tests.
Now they do.