### PR TITLE
Harden assertions

### DIFF
--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -239,15 +239,12 @@ export function attach(
         parentFiber == null ? null : getDataForFiber(parentFiber);
       const parentFiberDisplayName =
         (parentFiberData && parentFiberData.displayName) || 'null';
+      // NOTE: calling getFiberID or getPrimaryFiber is unsafe here
+      // because it will put them in the map. For now, we'll omit them.
+      // TODO: better debugging story for this.
       console.log(
-        `[renderer] %c${name} %c${getFiberID(
-          getPrimaryFiber(fiber)
-        )}:${fiberDisplayName} %c${
-          parentFiber
-            ? getFiberID(getPrimaryFiber(parentFiber)) +
-              ':' +
-              parentFiberDisplayName
-            : ''
+        `[renderer] %c${name} %c${fiberDisplayName} %c${
+          parentFiber ? parentFiberDisplayName : ''
         }`,
         'color: red; font-weight: bold;',
         'color: blue;',

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -711,8 +711,16 @@ export default class Store extends EventEmitter {
 
           element = ((this._idToElement.get(id): any): Element);
           parentID = element.parentID;
-
           weightDelta = -element.weight;
+
+          if (element.children.length > 0) {
+            throw new Error(
+              'Fiber ' +
+                id +
+                ' was removed before its children. ' +
+                'This is a bug in React DevTools.'
+            );
+          }
 
           this._idToElement.delete(id);
 
@@ -769,7 +777,16 @@ export default class Store extends EventEmitter {
           }
 
           element = ((this._idToElement.get(id): any): Element);
+          const prevChildren = element.children;
           element.children = Array.from(children);
+          if (element.children.length !== prevChildren.length) {
+            throw new Error(
+              'Fiber ' +
+                id +
+                ' received a different number of children on reorder. ' +
+                'This is a bug in React DevTools.'
+            );
+          }
 
           if (!element.isCollapsed) {
             const prevWeight = element.weight;


### PR DESCRIPTION
- Asserts the node count is the same between reorders
- Asserts we remove children first
- Removes the ID logging which creates a DEV-only side effect

