### PR TITLE
Filter out dehydrated Suspense nodes

### DIFF
--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -89,6 +89,7 @@ function getInternalReactConstants(version) {
       ContextProvider: 10,
       CoroutineComponent: -1, // Removed
       CoroutineHandlerPhase: -1, // Removed
+      DehydratedSuspenseComponent: 18, // Behind a flag
       EventComponent: 19, // Added in 16.9
       EventTarget: 20, // Added in 16.9
       ForwardRef: 11,
@@ -115,6 +116,7 @@ function getInternalReactConstants(version) {
       ContextProvider: 12,
       CoroutineComponent: -1, // Removed
       CoroutineHandlerPhase: -1, // Removed
+      DehydratedSuspenseComponent: -1, // Doesn't exist yet
       EventComponent: -1, // Doesn't exist yet
       EventTarget: -1, // Doesn't exist yet
       ForwardRef: 13,
@@ -141,6 +143,7 @@ function getInternalReactConstants(version) {
       ContextProvider: 13,
       CoroutineComponent: 7,
       CoroutineHandlerPhase: 8,
+      DehydratedSuspenseComponent: -1, // Doesn't exist yet
       EventComponent: -1, // Doesn't exist yet
       EventTarget: -1, // Doesn't exist yet
       ForwardRef: 14,
@@ -188,6 +191,7 @@ export function attach(
     FunctionComponent,
     ClassComponent,
     ContextConsumer,
+    DehydratedSuspenseComponent,
     EventComponent,
     EventTarget,
     Fragment,
@@ -267,6 +271,13 @@ export function attach(
       case MemoComponent:
       case SimpleMemoComponent:
         return false;
+      case DehydratedSuspenseComponent:
+        // TODO: ideally we would show dehydrated Suspense immediately.
+        // However, it has some special behavior (like disconnecting
+        // an alternate and turning into real Suspense) which breaks DevTools.
+        // For now, ignore it, and only show it once it gets hydrated.
+        // https://github.com/bvaughn/react-devtools-experimental/issues/197
+        return true;
       case EventComponent:
       case HostPortal:
       case HostComponent:


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/197.

This fix is not ideal. In particular, it makes dehydrated Suspense nodes appear *hidden* rather than empty. Conceptually, they're showing a server-rendered fallback, but we don't have React tree for it yet. Maybe it would be nice to show `<Suspense>` in the tree for them, but currently it's too broken so I opted to completely hide them until their hydration instead.

The reason we need this is because dehydrated Suspense nodes have funky behavior like [this](https://github.com/facebook/react/blob/d584fcdc6e10b9f4d4e9eec775731e7ffc0fb501/packages/react-reconciler/src/ReactFiberBeginWork.js#L1695-L1721) which I think violates some assumptions made by DevTools (e.g. we don't expect a Fiber to pretend it's a completely new one and disconnect its alternate). See https://github.com/bvaughn/react-devtools-experimental/issues/198 for a broader issue.

Unfortunately I can't easily write a test for this because partial hydration is only enabled behind a flag. Here's an app shell fixture I used to test it manually. It's based on tests from https://github.com/facebook/react/pull/14884. Note you'll have to toggle `enableSuspenseServerRenderer` flag in the bundle for this to work:

<details>

```js
/** @flow */

// This test harness mounts each test app as a separate root to test multi-root applications.

import React from 'react';
import ReactDOM from 'react-dom';
import ReactDOMServer from 'react-dom/server'
import DeeplyNestedComponents from './DeeplyNestedComponents';
import EditableProps from './EditableProps';
import ElementTypes from './ElementTypes';
import InspectableElements from './InspectableElements';
import InteractionTracing from './InteractionTracing';
import ToDoList from './ToDoList';
import Toggle from './Toggle';
import SuspenseTree from './SuspenseTree';

import './styles.css';

const containers = [];


function mountTestApp1() {
  const container = document.createElement('div');

  ((document.body: any): HTMLBodyElement).appendChild(container);

  containers.push(container);

    let suspend = false;
    let promise = new Promise(resolvePromise => {});
    let ref = React.createRef();

    function Child() {
      if (suspend) {
        throw promise;
      } else {
        return 'Hello';
      }
    }

    function App() {
      return (
        <div>
          <React.Suspense fallback="Loading...">
            <span ref={ref}>
              <Child />
            </span>
          </React.Suspense>
        </div>
      );
    }

    // We're going to simulate what Fizz will do during streaming rendering.

    suspend = true;
    let loadingHTML = ReactDOMServer.renderToString(<App />);
    suspend = false;
    let finalHTML = ReactDOMServer.renderToString(<App />);

    container.innerHTML = loadingHTML;
    containers.push(container);

    let suspenseNode = container.firstChild.firstChild;
    suspenseNode.data = '$?';

    function streamInContent() {
      let temp = document.createElement('div');
      temp.innerHTML = finalHTML;
      let finalSuspenseNode = temp.firstChild.firstChild;
      let fallbackContent = suspenseNode.nextSibling;
      let finalContent = finalSuspenseNode.nextSibling;
      suspenseNode.parentNode.replaceChild(finalContent, fallbackContent);
      suspenseNode.data = '$';
      if (suspenseNode._reactRetry) {
        suspenseNode._reactRetry();
      }
    }

    suspend = false;
    let root = ReactDOM.unstable_createRoot(container, {hydrate: true});
    root.render(<App />);

    setTimeout(() => {
      streamInContent();  
    }, 1000)

    setTimeout(() => {
      root.render(<App />);
    }, 2000);

    
}

function mountTestApp2() {
  const container = document.createElement('div');

  ((document.body: any): HTMLBodyElement).appendChild(container);

  containers.push(container);
   let suspend = false;
    let promise = new Promise(resolvePromise => {});
    let ref = React.createRef();

    function Child() {
      if (suspend) {
        throw promise;
      } else {
        return 'Hello';
      }
    }

    function App() {
      return (
        <div>
          <React.Suspense fallback="Loading...">
            <span ref={ref}>
              <Child />
            </span>
          </React.Suspense>
        </div>
      );
    }

    suspend = true;
    let finalHTML = ReactDOMServer.renderToString(<App />);
    container.innerHTML = finalHTML;

    suspend = false;
    let root = ReactDOM.unstable_createRoot(container, {hydrate: true});
    root.render(<App />);
}

function unmountTestApp() {
  // containers.forEach(container => unmountComponentAtNode(container));
}

mountTestApp1();
mountTestApp2();

// window.parent.mountTestApp = mountTestApp;
// window.parent.unmountTestApp = unmountTestApp;
```

</details>

### Before

Note how primary child doesn't appear until we toggle it once, and how the second example has a duplicate Suspense (one of which is completely borked).

![1](https://user-images.githubusercontent.com/810438/56457478-73ff2280-6373-11e9-870a-d2b7a01037fa.gif)

### After

Suspense nodes only show up after they're hydrated, and they work fine.

![2](https://user-images.githubusercontent.com/810438/56457483-782b4000-6373-11e9-9f9f-763eec67703d.gif)

### Follow-ups

We might want to reevaluate this later and support dehydrated Suspense more comprehensively. But I wouldn't want to add this until we can at least run tests against it.