### PR TITLE
Clear DOM overlay on shutdown

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -402,6 +402,8 @@ export default class Agent extends EventEmitter {
   };
 
   shutdown = () => {
+    // Clean up the overlay if visible, and associated events.
+    this.stopInspectingDOM();
     this.emit('shutdown');
   };
 


### PR DESCRIPTION
This ensures it doesn't get stuck if you Cmd+Shift+I out of DevTools. Also ensures they don't "stack up" when you launch a new DevTools window after that.