### PR TITLE
Fix scrolling to selected row in collapsed mode

### DIFF
--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -429,6 +429,21 @@ export default class Store extends EventEmitter {
     return null;
   }
 
+  isInsideCollapsedSubTree(id: number): boolean {
+    let current = this._idToElement.get(id);
+    while (current != null) {
+      if (current.parentID === 0) {
+        return false;
+      } else {
+        current = this._idToElement.get(current.parentID);
+        if (current != null && current.isCollapsed) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   startProfiling(): void {
     this._bridge.send('startProfiling');
 

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -596,6 +596,20 @@ function TreeContextController({ children, viewElementSource }: Props) {
           state = reduceTreeState(store, state, action);
           state = reduceSearchState(store, state, action);
           state = reduceOwnersState(store, state, action);
+
+          // If the selected ID is in a collapsed subtree, reset the selected index to null.
+          // We'll know the correct index after the layout effect will toggle the tree,
+          // and the store tree is mutated to account for that.
+          if (
+            state.selectedElementID !== null &&
+            store.isInsideCollapsedSubTree(state.selectedElementID)
+          ) {
+            return {
+              ...state,
+              selectedElementIndex: null,
+            };
+          }
+
           return state;
         default:
           throw new Error(`Unrecognized action "${type}"`);


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/189.

If we've selected an ID which is inside a collapsed subtree, its index can't be valid. We can't scroll to it. However, we don't want to "forget" the selection either.

Instead, we'll temporarily forget the index (but remember the ID) just before we exit the reducer. When the store is reconciled with selection in the layout effect, the index will be automatically recalculate. That, in turn, will trigger the scroll effect to the right index.