### PR TITLE
Replace WeakSet with return pointer check

### DIFF
--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -589,11 +589,6 @@ export function attach(
   let pendingSimulatedUnmountedIDs: Array<number> = [];
   let pendingOperationsQueue: Array<Uint32Array> | null = [];
 
-  // We keep track of which Fibers have been reported as unmounted by React
-  // during this commit phase so that we don't try to "hide" them or their
-  // children when Suspense flips to fallback. These Fibers won't have IDs.
-  let fibersUnmountedInThisCommitPhase: WeakSet<Fiber> = new WeakSet();
-
   // TODO: we could make this layer DEV-only and write directly to pendingOperations.
   let nextOperation: Array<number> = [];
   function beginNextOperation(size: number): void {
@@ -683,7 +678,6 @@ export function attach(
     pendingOperations.length = 0;
     pendingRealUnmountedIDs.length = 0;
     pendingSimulatedUnmountedIDs.length = 0;
-    fibersUnmountedInThisCommitPhase = new WeakSet();
   }
 
   function recordMount(fiber: Fiber, parentFiber: Fiber | null) {
@@ -890,9 +884,8 @@ export function attach(
 
     while (child !== null) {
       // Record simulated unmounts children-first.
-      // We might find real committed unmounts along the way--skip them.
-      // Otherwise we would send duplicated messages for the same IDs.
-      if (!fibersUnmountedInThisCommitPhase.has(child)) {
+      // We skip nodes without return because those are real unmounts.
+      if (child.return !== null) {
         unmountFiberChildrenRecursively(child);
         recordUnmount(child, true);
       }
@@ -1167,9 +1160,6 @@ export function attach(
   }
 
   function handleCommitFiberUnmount(fiber) {
-    // Remeber this is a real deletion so we don't
-    // go down this tree when hiding Suspense nodes.
-    fibersUnmountedInThisCommitPhase.add(fiber);
     // This is not recursive.
     // We can't traverse fibers after unmounting so instead
     // we rely on React telling us about each unmount.


### PR DESCRIPTION
There is a simpler (and likely more efficient) way to check if a Fiber has really been unmounted — its `.return` pointer would be nulled out. I was feeling uneasy due to that `WeakSet` because I'm worried putting Fibers into weak sets can mess with VM optimizations. Such as if they turn it into an expando internally. This avoids it.

Curiously, technically even the `.return` check isn't necessary here anymore. If the Fiber is deleted, it wouldn't be in the map — and so `recordUnmount` would have bailed out by now because of its inner check. The only reason this didn't work before was because in `__DEV__` we used to call `getFiberID` for them in `debug()` calls, making those Fibers go into the map. However, even though this is fixed, I don't want to rely on this, and would prefer those `.return` guards to be explicit.