### PR TITLE
Ignore leading edge of find-by-DOM throttle

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -525,6 +525,9 @@ export default class Agent extends EventEmitter {
         this._bridge.send('selectFiber', id);
       }
     }),
-    200
+    200,
+    // Don't change the selection in the very first 200ms
+    // because those are usually unintentional as you lift the cursor.
+    { leading: false }
   );
 }


### PR DESCRIPTION
The first few moments are usually spent lifting the cursor from the button to the actual place you wanna select. Since the highlighting in the browser is instantaneous anyway and will grab our attention, there's no need to immediately reflect the leading edge in the item selection. We will likely hover over the wrong thing at first. This helps avoid unintentionally expanding trees in more cases.