### PR TITLE
Support highlighting of all DOM elements of Fragments, not just first

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -276,18 +276,19 @@ export default class Agent extends EventEmitter {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     }
 
-    let node: HTMLElement | null = null;
+    let nodes: ?Array<HTMLElement> = null;
     if (renderer !== null) {
-      node = ((renderer.findNativeByFiberID(id): any): HTMLElement);
+      nodes = ((renderer.findNativeByFiberID(id): any): ?Array<HTMLElement>);
     }
 
-    if (node != null) {
+    if (nodes != null && nodes[0] != null) {
+      const node = nodes[0];
       if (scrollIntoView && typeof node.scrollIntoView === 'function') {
         // If the node isn't visible show it before highlighting it.
         // We may want to reconsider this; it might be a little disruptive.
         node.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       }
-      showOverlay(((node: any): HTMLElement), displayName, hideAfterTimeout);
+      showOverlay(nodes, displayName, hideAfterTimeout);
       if (openNativeElementsPanel) {
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
         this._bridge.send('syncSelectionToNativeElementsPanel');
@@ -585,7 +586,7 @@ export default class Agent extends EventEmitter {
 
     // Don't pass the name explicitly.
     // It will be inferred from DOM tag and Fiber owner.
-    showOverlay(target, null, false);
+    showOverlay([target], null, false);
 
     this._selectFiberForNode(target);
   };

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -25,7 +25,6 @@ export type RendererID = number;
 type Dispatcher = any;
 
 export type ReactRenderer = {
-  findHostInstanceByFiber: (fiber: Object) => ?NativeType,
   findFiberByHostInstance: (hostInstance: NativeType) => ?Fiber,
   version: string,
   bundleType: BundleType,
@@ -103,7 +102,7 @@ export type PathMatch = {|
 
 export type RendererInterface = {
   cleanup: () => void,
-  findNativeByFiberID: (id: number) => ?NativeType,
+  findNativeByFiberID: (id: number) => ?Array<NativeType>,
   flushInitialOperations: () => void,
   getBestMatchForTrackedPath: () => PathMatch | null,
   getCommitDetails: (rootID: number, commitIndex: number) => CommitDetails,

--- a/src/backend/views/Highlighter.js
+++ b/src/backend/views/Highlighter.js
@@ -17,7 +17,7 @@ export function hideOverlay() {
 }
 
 export function showOverlay(
-  element: HTMLElement | null,
+  elements: Array<HTMLElement> | null,
   componentName: string | null,
   hideAfterTimeout: boolean
 ) {
@@ -25,7 +25,7 @@ export function showOverlay(
     clearTimeout(timeoutID);
   }
 
-  if (element == null) {
+  if (elements == null) {
     return;
   }
 
@@ -33,7 +33,7 @@ export function showOverlay(
     overlay = new Overlay();
   }
 
-  overlay.inspect(element, componentName);
+  overlay.inspect(elements, componentName);
 
   if (hideAfterTimeout) {
     timeoutID = setTimeout(hideOverlay, SHOW_DURATION);


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/131

Uses the new function `findAllCurrentHostFibers`.

Removes dependency on React's `renderer.findHostInstanceByFiber` function
which used to highlight only the first DOM element of a Fragment.

Reworked `src/backend/views/Overlay` to support highlighting
more than one element rectangle annotated with one tooltip.
Fixed minor issues with the tooltip position calculation.

<img width="817" alt="Screen Shot 2019-04-20 at 11 48 02 PM" src="https://user-images.githubusercontent.com/498274/56466415-d3d2e900-63c6-11e9-9979-c475bb7d2716.png">
