### PR TITLE
Add arrow to overlay tip pointing where to look for offscreen elements

### DIFF
--- a/shells/dev/app/Offscreen/index.js
+++ b/shells/dev/app/Offscreen/index.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+function Positioned({ style }) {
+  return (
+    <div style={{ position: 'absolute', width: 0, height: 0, ...style }} />
+  );
+}
+
+function OffscreenLeftTop() {
+  return <Positioned style={{ left: '-200vw', top: '-200vh' }} />;
+}
+function OffscreenTop() {
+  return <Positioned style={{ left: '50vw', top: '-200vh' }} />;
+}
+function OffscreenRightTop() {
+  return <Positioned style={{ left: '200vw', top: '-200vh' }} />;
+}
+function OffscreenRight() {
+  return <Positioned style={{ left: '200vw', top: '50vh' }} />;
+}
+function OffscreenRightBottom() {
+  return <Positioned style={{ left: '200vw', top: '200vh' }} />;
+}
+function OffscreenBottom() {
+  return <Positioned style={{ left: '50vw', top: '200vh' }} />;
+}
+function OffscreenLeftBottom() {
+  return <Positioned style={{ left: '-200vw', top: '200vh' }} />;
+}
+function OffscreenLeft() {
+  return <Positioned style={{ left: '-200vw', top: '50vh' }} />;
+}
+
+export default function Offscreen() {
+  return (
+    <>
+      <h2>Offscreen (tooltip test)</h2>
+      <div>
+        <OffscreenLeftTop />
+        <OffscreenTop />
+        <OffscreenRightTop />
+        <OffscreenRight />
+        <OffscreenRightBottom />
+        <OffscreenBottom />
+        <OffscreenLeftBottom />
+        <OffscreenLeft />
+      </div>
+    </>
+  );
+}

--- a/shells/dev/app/index.js
+++ b/shells/dev/app/index.js
@@ -9,6 +9,7 @@ import EditableProps from './EditableProps';
 import ElementTypes from './ElementTypes';
 import InspectableElements from './InspectableElements';
 import InteractionTracing from './InteractionTracing';
+import Offscreen from './Offscreen';
 import ToDoList from './ToDoList';
 import Toggle from './Toggle';
 import SuspenseTree from './SuspenseTree';
@@ -33,6 +34,7 @@ function mountTestApp() {
   mountHelper(InspectableElements);
   mountHelper(ElementTypes);
   mountHelper(EditableProps);
+  mountHelper(Offscreen);
   mountHelper(Toggle);
   mountHelper(SuspenseTree);
   mountHelper(DeeplyNestedComponents);


### PR DESCRIPTION
This change builds on top of the overlay rework for multiple highlighted rectangles:
https://github.com/bvaughn/react-devtools-experimental/pull/207

If the highlighted elements are offscreen, the tooltip is positioned
towards these elements, but the element highlights (OverlayRect)
are not visible, so if the element size is zero or close to it,
it's hard to visually tell apart an onscreen element located where
the tooltip is positioned and an offscreen element located elsewhere.

This change improves the UX by adding to the tooltips
a little arrow pointing to where the elements are located
if they are offscreen.

For onscreen elements the tooltip does not change.

![overlay-tip-direction-arrow-demo](https://user-images.githubusercontent.com/498274/57205141-44eed080-6f71-11e9-9e88-e8731a756f31.gif)
