### PR TITLE
Implement showing native elements under a persisted Settings item

### DIFF
--- a/shells/browser/shared/src/main.js
+++ b/shells/browser/shared/src/main.js
@@ -68,6 +68,9 @@ function createPanelIfReactLoaded() {
           localStorage.setItem(LOCAL_STORAGE_SUPPORTS_PROFILING_KEY, 'true');
           chrome.devtools.inspectedWindow.eval('window.location.reload();');
         });
+        bridge.addListener('reloadAppForShowNativeElements', () => {
+          chrome.devtools.inspectedWindow.eval('window.location.reload();');
+        });
         bridge.addListener('exportFile', ({ contents, filename }) => {
           chrome.runtime.sendMessage({
             exportFile: true,
@@ -109,6 +112,7 @@ function createPanelIfReactLoaded() {
           supportsFileDownloads: browserName === 'Chrome',
           supportsReloadAndProfile: true,
           supportsProfiling,
+          supportsShowingNativeElements: true,
         });
 
         // Initialize the backend only once the Store has been initialized.

--- a/shells/dev/src/devtools.js
+++ b/shells/dev/src/devtools.js
@@ -2,7 +2,7 @@
 
 import { createElement } from 'react';
 // $FlowFixMe Flow does not yet know about createRoot()
-import { unstable_createRoot as createRoot } from 'react-dom';
+import { unstable_createRoot as createRoot, flushSync } from 'react-dom';
 import Bridge from 'src/bridge';
 import { installHook } from 'src/hook';
 import { initDevTools } from 'src/devtools';
@@ -10,11 +10,6 @@ import Store from 'src/devtools/store';
 import DevTools from 'src/devtools/views/DevTools';
 
 const iframe = ((document.getElementById('target'): any): HTMLIFrameElement);
-
-const { contentDocument, contentWindow } = iframe;
-
-installHook(contentWindow);
-
 const container = ((document.getElementById('devtools'): any): HTMLElement);
 
 let isTestAppMounted = true;
@@ -38,54 +33,142 @@ mountButton.addEventListener('click', function() {
   }
 });
 
-inject('./build/app.js', () => {
-  initDevTools({
-    connect(cb) {
-      const bridge = new Bridge({
-        listen(fn) {
-          contentWindow.parent.addEventListener('message', ({ data }) => {
-            fn(data);
-          });
-        },
-        send(event: string, payload: any, transferable?: Array<any>) {
-          contentWindow.postMessage({ event, payload }, '*', transferable);
-        },
-      });
+// It's safe to close over `iframe.contentWindow` as it does not change with iframe reload.
+// But we'll have to `installHook` every time the iframe loads empty.
+const { contentWindow } = iframe;
 
-      cb(bridge);
+let bridge = null;
+let store = null;
+let root = null;
+let render = null;
 
-      const store = new Store(bridge, { supportsCaptureScreenshots: true });
+// Unlike the extension, here we only have one port, which is the `iframe.contentWindow`, which we do not recreate.
+// So we ensure that we stop listening as soon as the bridge is shutdown to prevent the old bridge from receiving
+// the messages sent to the newly created one.
+const listeners = [];
+let bridgeId = null;
 
-      const root = createRoot(container);
-      const batch = root.createBatch();
-      batch.render(
-        createElement(DevTools, {
-          bridge,
-          browserName: 'Chrome',
-          browserTheme: 'light',
-          showTabBar: true,
-          store,
-        })
-      );
-      batch.then(() => {
-        batch.commit();
-
-        // Initialize the backend only once the DevTools frontend Store has been initialized.
-        // Otherwise the Store may miss important initial tree op codes.
-        inject('./build/backend.js');
-      });
+function initBridgeAndStore() {
+  const thisBridgeId = (bridgeId = Math.random());
+  bridge = new Bridge({
+    listen(fn) {
+      // Prevent the subscriptions via the older bridge to the newer bridge messages.
+      if (bridgeId !== thisBridgeId) {
+        return;
+      }
+      const listener = ({ data }) => {
+        fn(data);
+      };
+      listeners.push(listener);
+      contentWindow.parent.addEventListener('message', listener);
     },
-
-    onReload(reloadFn) {
-      iframe.onload = reloadFn;
+    send(event: string, payload: any, transferable?: Array<any>) {
+      // Prevent the message from being sent via the older bridge to the newer bridge.
+      if (bridgeId !== thisBridgeId) {
+        return;
+      }
+      contentWindow.postMessage({ event, payload }, '*', transferable);
     },
   });
-});
+
+  bridge.addListener('reloadAppForShowNativeElements', () => {
+    // Prevent the events from the older bridge to be handled when the newer bridge is active.
+    if (bridgeId !== thisBridgeId) {
+      return;
+    }
+    // Use the same approach to reload the iframe window as the browser extension uses.
+    contentWindow.eval('window.location.reload();');
+  });
+
+  store = new Store(bridge, {
+    supportsCaptureScreenshots: true,
+    supportsShowingNativeElements: true,
+  });
+
+  // Initialize the backend only once the Store has been initialized.
+  // Otherwise the Store may miss important initial tree op codes.
+  inject('./build/backend.js');
+
+  root = createRoot(container);
+
+  render = () => {
+    if (!root || !bridge || !store) {
+      throw new Error(
+        'Missing root, bridge, or store inside render. Should never happen.'
+      );
+    }
+    root.render(
+      createElement(DevTools, {
+        bridge,
+        browserName: 'Chrome',
+        browserTheme: 'light',
+        showTabBar: true,
+        store,
+      })
+    );
+  };
+
+  render();
+}
+
+// Shutdown bridge and re-initialize DevTools panel when a new page is loaded.
+function onNavigated() {
+  if (!bridge) {
+    throw new Error('Missing bridge inside onNavigated. Should never happen.');
+  }
+
+  bridge.send('shutdown');
+
+  // Remove all listeners of this bridge to prevent stale messages from being handled after shutdown.
+  listeners.forEach(fn => {
+    window.removeEventListener('message', fn);
+  });
+  listeners.splice(0);
+
+  // It's easiest to recreate the DevTools panel (to clean up potential stale state).
+  // We can revisit this in the future as a small optimization.
+  flushSync(() => {
+    if (!root) {
+      throw new Error(
+        'Missing root inside flushSync callback. Should never happen.'
+      );
+    }
+
+    root.unmount();
+  });
+}
+
+function onEmptyAppIframe() {
+  // Ensure unloaded here, more reliable than iframe 'beforeunload'.
+  if (bridge) {
+    onNavigated();
+  }
+
+  installHook(contentWindow);
+
+  inject('./build/app.js', () => {
+    initDevTools({
+      connect(cb) {
+        initBridgeAndStore();
+        cb(bridge);
+      },
+
+      onReload(reloadFn) {
+        iframe.onload = reloadFn;
+      },
+    });
+  });
+}
 
 function inject(sourcePath, callback) {
-  const script = contentDocument.createElement('script');
+  // `iframe.contentDocument` changes on iframe reload, so we do not close over it.
+  const script = iframe.contentDocument.createElement('script');
   script.onload = callback;
   script.src = sourcePath;
 
-  ((contentDocument.body: any): HTMLBodyElement).appendChild(script);
+  ((iframe.contentDocument.body: any): HTMLBodyElement).appendChild(script);
 }
+
+onEmptyAppIframe();
+// 'DOMContentLoaded' does not trigger when iframe loads empty, but 'load' does.
+iframe.addEventListener('load', onEmptyAppIframe);

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -136,6 +136,7 @@ export type RendererInterface = {
   setTrackedPath: (path: Array<PathFrame> | null) => void,
   startProfiling: () => void,
   stopProfiling: () => void,
+  setShowNativeElements: (showNativeElements: boolean) => void,
 };
 
 export type Handler = (data: any) => void;

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,9 @@ export const TREE_OPERATION_UPDATE_TREE_BASE_DURATION = 4;
 export const LOCAL_STORAGE_RELOAD_AND_PROFILE_KEY =
   'React::DevTools::reloadAndProfile';
 
+export const LOCAL_STORAGE_SHOULD_SHOW_NATIVE_ELEMENTS_KEY =
+  'React::DevTools::reloadAndSetShowNativeElements';
+
 export const SESSION_STORAGE_LAST_SELECTION_KEY =
   'React::DevTools::lastSelection';
 

--- a/src/devtools/types.js
+++ b/src/devtools/types.js
@@ -11,8 +11,10 @@ export const ElementTypeOtherOrUnknown = 8;
 export const ElementTypeProfiler = 9;
 export const ElementTypeRoot = 10;
 export const ElementTypeSuspense = 11;
+export const ElementTypeHostComponent = 12;
+export const ElementTypeHostText = 13;
 
 // Different types of elements displayed in the Elements tree.
 // These types may be used to visually distinguish types,
 // or to enable/disable certain functionality.
-export type ElementType = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+export type ElementType = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;

--- a/src/devtools/views/Components/Element.css
+++ b/src/devtools/views/Components/Element.css
@@ -28,6 +28,8 @@
 
   /* Invert colors */
   --color-component-name: var(--color-component-name-inverted);
+  --color-host-component-name: var(--color-host-component-name-inverted);
+  --color-host-text: var(--color-host-text-inverted);
   --color-jsx-arrow-brackets: var(--color-jsx-arrow-brackets-inverted);
   --color-attribute-name: var(--color-background-hover);
   --color-attribute-value: var(--color-component-name-inverted);
@@ -49,6 +51,35 @@
 .Component:after {
   white-space: nowrap;
   content: '>';
+  color: var(--color-jsx-arrow-brackets);
+}
+
+.HostComponent {
+  color: var(--color-host-component-name);
+}
+.HostComponent:before {
+  white-space: nowrap;
+  content: '<';
+  color: var(--color-jsx-arrow-brackets);
+}
+.HostComponent:after {
+  white-space: nowrap;
+  content: '>';
+  color: var(--color-jsx-arrow-brackets);
+}
+
+.HostText {
+  white-space: pre-wrap;
+  color: var(--color-host-text);
+}
+.HostText:before {
+  white-space: nowrap;
+  content: '"';
+  color: var(--color-jsx-arrow-brackets);
+}
+.HostText:after {
+  white-space: nowrap;
+  content: '"';
   color: var(--color-jsx-arrow-brackets);
 }
 

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -9,7 +9,12 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ElementTypeClass, ElementTypeFunction } from 'src/devtools/types';
+import {
+  ElementTypeClass,
+  ElementTypeFunction,
+  ElementTypeHostComponent,
+  ElementTypeHostText,
+} from 'src/devtools/types';
 import Store from 'src/devtools/store';
 import ButtonIcon from '../ButtonIcon';
 import { createRegExp } from '../utils';
@@ -171,7 +176,15 @@ export default function ElementView({ data, index, style }: Props) {
       {ownerStack.length === 0 ? (
         <ExpandCollapseToggle element={element} store={store} />
       ) : null}
-      <span className={styles.Component}>
+      <span
+        className={
+          type === ElementTypeHostComponent
+            ? styles.HostComponent
+            : type === ElementTypeHostText
+            ? styles.HostText
+            : styles.Component
+        }
+      >
         <DisplayName displayName={displayName} id={((id: any): number)} />
         {key && (
           <Fragment>

--- a/src/devtools/views/Components/SelectedElement.css
+++ b/src/devtools/views/Components/SelectedElement.css
@@ -52,8 +52,39 @@
   color: var(--color-jsx-arrow-brackets);
 }
 
-.Component {
+.Component,
+.HostComponent,
+.HostText {
   flex: 1 1 auto;
+}
+
+.HostComponent {
+  color: var(--color-host-component-name);
+}
+.HostComponent:before {
+  white-space: nowrap;
+  content: '<';
+  color: var(--color-jsx-arrow-brackets);
+}
+.HostComponent:after {
+  white-space: nowrap;
+  content: '>';
+  color: var(--color-jsx-arrow-brackets);
+}
+
+.HostText {
+  white-space: pre-wrap;
+  color: var(--color-host-text);
+}
+.HostText:before {
+  white-space: nowrap;
+  content: '"';
+  color: var(--color-jsx-arrow-brackets);
+}
+.HostText:after {
+  white-space: nowrap;
+  content: '"';
+  color: var(--color-jsx-arrow-brackets);
 }
 
 .InspectedElement {

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -16,6 +16,8 @@ import {
   ElementTypeFunction,
   ElementTypeMemo,
   ElementTypeSuspense,
+  ElementTypeHostComponent,
+  ElementTypeHostText,
 } from '../../types';
 
 import type { Element, InspectedElement } from './types';
@@ -85,11 +87,22 @@ export default function SelectedElement(_: Props) {
     inspectedElement.canViewSource &&
     viewElementSource !== null;
 
+  const { type } = element;
+
   return (
     <div className={styles.SelectedElement}>
       <div className={styles.TitleRow}>
         <div className={styles.SelectedComponentName}>
-          <div className={styles.Component} title={element.displayName}>
+          <div
+            className={
+              type === ElementTypeHostComponent
+                ? styles.HostComponent
+                : type === ElementTypeHostText
+                ? styles.HostText
+                : styles.Component
+            }
+            title={element.displayName}
+          >
             {element.displayName}
           </div>
         </div>
@@ -198,12 +211,21 @@ function InspectedElementView({
 
   return (
     <div className={styles.InspectedElement}>
-      <InspectedElementTree
-        label="props"
-        data={props}
-        overrideValueFn={overridePropsFn}
-        showWhenEmpty
-      />
+      {type === ElementTypeHostText ? (
+        <InspectedElementTree
+          label="text"
+          data={props}
+          overrideValueFn={null}
+          showWhenEmpty
+        />
+      ) : (
+        <InspectedElementTree
+          label="props"
+          data={props}
+          overrideValueFn={overridePropsFn}
+          showWhenEmpty
+        />
+      )}
       {type === ElementTypeSuspense ? (
         <InspectedElementTree
           label="suspense"

--- a/src/devtools/views/Components/types.js
+++ b/src/devtools/views/Components/types.js
@@ -40,6 +40,8 @@ export type InspectedElement = {|
 
   displayName: string | null,
 
+  type: ElementType,
+
   // Does the current renderer support editable hooks?
   canEditHooks: boolean,
 

--- a/src/devtools/views/Settings/SettingsContext.js
+++ b/src/devtools/views/Settings/SettingsContext.js
@@ -228,6 +228,14 @@ function updateThemeVariables(
   updateStyleHelper(theme, 'color-commit-gradient-text', documentElements);
   updateStyleHelper(theme, 'color-component-name', documentElements);
   updateStyleHelper(theme, 'color-component-name-inverted', documentElements);
+  updateStyleHelper(theme, 'color-host-component-name', documentElements);
+  updateStyleHelper(
+    theme,
+    'color-host-component-name-inverted',
+    documentElements
+  );
+  updateStyleHelper(theme, 'color-host-text', documentElements);
+  updateStyleHelper(theme, 'color-host-text-inverted', documentElements);
   updateStyleHelper(theme, 'color-dim', documentElements);
   updateStyleHelper(theme, 'color-dimmer', documentElements);
   updateStyleHelper(theme, 'color-dimmest', documentElements);

--- a/src/devtools/views/root.css
+++ b/src/devtools/views/root.css
@@ -33,6 +33,10 @@
   --light-color-commit-gradient-text: #000000;
   --light-color-component-name: #6a51b2;
   --light-color-component-name-inverted: #ffffff;
+  --light-color-host-component-name: #881280;
+  --light-color-host-component-name-inverted: #ffffff;
+  --light-color-host-text: #303942;
+  --light-color-host-text-inverted: rgba(255, 255, 255, 0.7);
   --light-color-dim: #777d88;
   --light-color-dimmer: #cfd1d5;
   --light-color-dimmest: #eff0f1;
@@ -80,7 +84,11 @@
   --dark-color-commit-gradient-9: #febc38;
   --dark-color-commit-gradient-text: #000000;
   --dark-color-component-name: #61dafb;
-  --dark-color-component-name-inverted: ##282828;
+  --dark-color-component-name-inverted: #282c34;
+  --dark-color-host-component-name: #53ffc2;
+  --dark-color-host-component-name-inverted: #282c34;
+  --dark-color-host-text: #cfd0d0;
+  --dark-color-host-text-inverted: #cfd0d0;
   --dark-color-dim: #8f949d;
   --dark-color-dimmer: #777d88;
   --dark-color-dimmest: #4f5766;


### PR DESCRIPTION
It's often necessary to debug native (host) elements rendered by
the components, but the new version of DevTools removed this functionality.

This change restores the functionality under a persisted setting,
working similar to "reload and profile", so that by default
the performance of the DevTools is unaffected.

To distinguish the HostComponent and HostText types in Components,
new ElementType items were added, and new CSS variables were added
for colors in both light and dart themes.

Within this diff there's also a fix to the shells/dev iframe reload handling.
Previously reloading the iframe would not restore the test app
and would break the bridge/store. This diff more accurately resembles
the load/unload/messaging behavior and the code written for the extension.

The reasoning for this feature to exist:

> I want to do the reverse: from the tree find where are my elements.
> Not every element that gets rendered is visible and of clickable size.
> https://twitter.com/sompylasar/status/1118580156430311424
> https://twitter.com/dan_abramov/status/1118486315736158208

![Kapture 2019-04-21 at 15 11 14](https://user-images.githubusercontent.com/498274/56476130-efca9f00-6447-11e9-8fc8-f3228537eec4.gif)

CC @gaearon 