### PR TITLE
fix: correct permissions for Firefox

### DIFF
--- a/shells/browser/firefox/manifest.json
+++ b/shells/browser/firefox/manifest.json
@@ -46,8 +46,8 @@
 
   "permissions": [
     "<all_urls>",
-    "background",
     "downloads",
+    "activeTab",
     "tabs",
     "file:///*",
     "http://*/*",


### PR DESCRIPTION
remove the `background` permissions as it's not used by Firefox, but `activeTab` is and we needed it.

fix #136

@bvaughn we may want to check the rest of this list for any others we might want specifically but from my testing this made it usable. 😄 

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions