### PR TITLE
Select parent node if selection is removed

### DIFF
--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -540,7 +540,7 @@ export default class Store extends EventEmitter {
         // The Tree context's search reducer expects an explicit list of ids for nodes that were added or removed.
         // In this  case, we can pass it empty arrays since nodes in a collapsed tree are still there (just hidden).
         // Updating the selected search index later may require auto-expanding a collapsed subtree though.
-        this.emit('mutated', [[], []]);
+        this.emit('mutated', [[], new Map()]);
       }
     }
   }
@@ -625,7 +625,9 @@ export default class Store extends EventEmitter {
     }
 
     const addedElementIDs: Array<number> = [];
-    const removedElementIDs: Array<number> = [];
+    // This is a mapping of removed ID -> parent ID:
+    const removedElementIDs: Map<number, number> = new Map();
+    // We'll use the parent ID to adjust selection if it gets deleted.
 
     let i = 2;
     while (i < operations.length) {
@@ -789,7 +791,7 @@ export default class Store extends EventEmitter {
             }
 
             this._adjustParentTreeWeight(parentElement, -element.weight);
-            removedElementIDs.push(id);
+            removedElementIDs.set(id, parentID);
           }
           break;
         }
@@ -871,10 +873,7 @@ export default class Store extends EventEmitter {
       console.groupEnd();
     }
 
-    this.emit('mutated', [
-      new Uint32Array(addedElementIDs),
-      new Uint32Array(removedElementIDs),
-    ]);
+    this.emit('mutated', [addedElementIDs, removedElementIDs]);
   };
 
   onProfilingStatus = (isProfiling: boolean) => {


### PR DESCRIPTION
If selected node gets unmounted, currently we reset the selection. This is somewhat disruptive because the next time you press "down" you'll jump to the top of the tree. It can be disorienting.

This fix adjusts selection to go the closest parent element that wasn't deleted in this batch. To make it work, I made `removedIDs` a Map of `removed ID -> parent ID`. We can't query the store about removed nodes by the time we receive an event, so this mapping helps us figure out which node to select instead.

I also changed `addedIDs` to be a regular array since I don't see what making it a typed array brings here. It isn't being transferred anywhere as far as I can tell, and we still used to create an array anyway. Might as well use that one.