### PR TITLE
Owners list view should drill through intermediate components

### DIFF
--- a/src/__tests__/__snapshots__/storeOwners-test.js.snap
+++ b/src/__tests__/__snapshots__/storeOwners-test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Store owners list should drill through intermediate components: 1: mount 1`] = `
+[root]
+  ▾ <Root>
+    ▾ <Intermediate>
+      ▾ <Wrapper>
+          <Leaf key="children">
+`;
+
+exports[`Store owners list should drill through intermediate components: 2: components owned by <Root> 1`] = `
+"  ▾ <Root>
+    ▾ <Intermediate>
+        <Leaf key=\\"children\\">"
+`;
+
+exports[`Store owners list should drill through intermediate components: 3: components owned by <Intermediate> 1`] = `
+"  ▾ <Intermediate>
+    ▾ <Wrapper>"
+`;

--- a/src/__tests__/__snapshots__/storeOwners-test.js.snap
+++ b/src/__tests__/__snapshots__/storeOwners-test.js.snap
@@ -1,20 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Store owners list should drill through interleaved intermediate components: 1: mount 1`] = `
+[root]
+  ▾ <Root>
+    ▾ <Intermediate key="intermediate">
+        <Leaf key="leaf">
+      ▾ <Wrapper key="wrapper">
+          <Leaf>
+      <Leaf key="leaf">
+`;
+
+exports[`Store owners list should drill through interleaved intermediate components: 2: components owned by <Root> 1`] = `
+"  ▾ <Root>
+    ▾ <Intermediate key=\\"intermediate\\">
+        <Leaf>
+      <Leaf key=\\"leaf\\">"
+`;
+
+exports[`Store owners list should drill through interleaved intermediate components: 3: components owned by <Intermediate> 1`] = `
+"  ▾ <Intermediate key=\\"intermediate\\">
+      <Leaf key=\\"leaf\\">
+    ▾ <Wrapper key=\\"wrapper\\">"
+`;
+
 exports[`Store owners list should drill through intermediate components: 1: mount 1`] = `
 [root]
   ▾ <Root>
     ▾ <Intermediate>
       ▾ <Wrapper>
-          <Leaf key="children">
+          <Leaf>
 `;
 
 exports[`Store owners list should drill through intermediate components: 2: components owned by <Root> 1`] = `
 "  ▾ <Root>
     ▾ <Intermediate>
-        <Leaf key=\\"children\\">"
+        <Leaf>"
 `;
 
 exports[`Store owners list should drill through intermediate components: 3: components owned by <Intermediate> 1`] = `
 "  ▾ <Intermediate>
     ▾ <Wrapper>"
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 1: mount 1`] = `
+[root]
+  ▾ <Root>
+    ▾ <Intermediate>
+      ▾ <Wrapper>
+          <Leaf>
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 2: components owned by <Root> 1`] = `
+"  ▾ <Root>
+    ▾ <Intermediate>
+        <Leaf>"
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 3: update to add direct 1`] = `
+[root]
+  ▾ <Root>
+      <Leaf>
+    ▾ <Intermediate>
+      ▾ <Wrapper>
+          <Leaf>
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 4: components owned by <Root> 1`] = `
+"  ▾ <Root>
+      <Leaf>
+    ▾ <Intermediate>
+        <Leaf>"
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 5: update to remove indirect 1`] = `
+[root]
+  ▾ <Root>
+      <Leaf>
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 6: components owned by <Root> 1`] = `
+"  ▾ <Root>
+      <Leaf>"
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 7: update to remove both 1`] = `
+[root]
+    <Root>
+`;
+
+exports[`Store owners list should show the proper owners list order and contents after insertions and deletions: 8: components owned by <Root> 1`] = `"    <Root>"`;
+
+exports[`Store owners list should show the proper owners list ordering after reordered children: 1: mount (ascending) 1`] = `
+[root]
+  ▾ <Root>
+      <Leaf key="A">
+      <Leaf key="B">
+      <Leaf key="C">
+`;
+
+exports[`Store owners list should show the proper owners list ordering after reordered children: 2: components owned by <Root> 1`] = `
+"  ▾ <Root>
+      <Leaf key=\\"A\\">
+      <Leaf key=\\"B\\">
+      <Leaf key=\\"C\\">"
+`;
+
+exports[`Store owners list should show the proper owners list ordering after reordered children: 3: update (descending) 1`] = `
+[root]
+  ▾ <Root>
+      <Leaf key="C">
+      <Leaf key="B">
+      <Leaf key="A">
+`;
+
+exports[`Store owners list should show the proper owners list ordering after reordered children: 4: components owned by <Root> 1`] = `
+"  ▾ <Root>
+      <Leaf key=\\"C\\">
+      <Leaf key=\\"B\\">
+      <Leaf key=\\"A\\">"
 `;

--- a/src/__tests__/storeOwners-test.js
+++ b/src/__tests__/storeOwners-test.js
@@ -1,0 +1,50 @@
+// @flow
+
+const { printOwnersList } = require('./storeSerializer');
+
+describe('Store owners list', () => {
+  let React;
+  let ReactDOM;
+  let TestUtils;
+  let store;
+
+  const act = (callback: Function) => {
+    TestUtils.act(() => {
+      callback();
+    });
+    jest.runAllTimers(); // Flush Bridge operations
+  };
+
+  beforeEach(() => {
+    store = global.store;
+    store.collapseNodesByDefault = false;
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    TestUtils = require('react-dom/test-utils');
+  });
+
+  it('should drill through intermediate components', () => {
+    const Root = () => (
+      <Intermediate>
+        <Leaf key="children" />
+      </Intermediate>
+    );
+    const Wrapper = ({ children }) => children;
+    const Leaf = () => <div>Leaf</div>;
+    const Intermediate = ({ children }) => <Wrapper>{children}</Wrapper>;
+
+    act(() => ReactDOM.render(<Root />, document.createElement('div')));
+    expect(store).toMatchSnapshot('1: mount');
+
+    const rootID = store.getElementIDAtIndex(0);
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('2: components owned by <Root>');
+
+    const intermediateID = store.getElementIDAtIndex(1);
+    expect(
+      printOwnersList(store.getOwnersListForElement(intermediateID))
+    ).toMatchSnapshot('3: components owned by <Intermediate>');
+  });
+});

--- a/src/__tests__/storeOwners-test.js
+++ b/src/__tests__/storeOwners-test.js
@@ -27,7 +27,9 @@ describe('Store owners list', () => {
   it('should drill through intermediate components', () => {
     const Root = () => (
       <Intermediate>
-        <Leaf key="children" />
+        <div>
+          <Leaf />
+        </div>
       </Intermediate>
     );
     const Wrapper = ({ children }) => children;
@@ -46,5 +48,124 @@ describe('Store owners list', () => {
     expect(
       printOwnersList(store.getOwnersListForElement(intermediateID))
     ).toMatchSnapshot('3: components owned by <Intermediate>');
+  });
+
+  it('should drill through interleaved intermediate components', () => {
+    const Root = () => [
+      <Intermediate key="intermediate">
+        <Leaf />
+      </Intermediate>,
+      <Leaf key="leaf" />,
+    ];
+    const Wrapper = ({ children }) => children;
+    const Leaf = () => <div>Leaf</div>;
+    const Intermediate = ({ children }) => [
+      <Leaf key="leaf" />,
+      <Wrapper key="wrapper">{children}</Wrapper>,
+    ];
+
+    act(() => ReactDOM.render(<Root />, document.createElement('div')));
+    expect(store).toMatchSnapshot('1: mount');
+
+    const rootID = store.getElementIDAtIndex(0);
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('2: components owned by <Root>');
+
+    const intermediateID = store.getElementIDAtIndex(1);
+    expect(
+      printOwnersList(store.getOwnersListForElement(intermediateID))
+    ).toMatchSnapshot('3: components owned by <Intermediate>');
+  });
+
+  it('should show the proper owners list order and contents after insertions and deletions', () => {
+    const Root = ({ includeDirect, includeIndirect }) => (
+      <div>
+        {includeDirect ? <Leaf /> : null}
+        {includeIndirect ? (
+          <Intermediate>
+            <Leaf />
+          </Intermediate>
+        ) : null}
+      </div>
+    );
+    const Wrapper = ({ children }) => children;
+    const Leaf = () => <div>Leaf</div>;
+    const Intermediate = ({ children }) => <Wrapper>{children}</Wrapper>;
+
+    const container = document.createElement('div');
+
+    act(() =>
+      ReactDOM.render(
+        <Root includeDirect={false} includeIndirect={true} />,
+        container
+      )
+    );
+    expect(store).toMatchSnapshot('1: mount');
+
+    const rootID = store.getElementIDAtIndex(0);
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('2: components owned by <Root>');
+
+    act(() =>
+      ReactDOM.render(
+        <Root includeDirect={true} includeIndirect={true} />,
+        container
+      )
+    );
+    expect(store).toMatchSnapshot('3: update to add direct');
+
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('4: components owned by <Root>');
+
+    act(() =>
+      ReactDOM.render(
+        <Root includeDirect={true} includeIndirect={false} />,
+        container
+      )
+    );
+    expect(store).toMatchSnapshot('5: update to remove indirect');
+
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('6: components owned by <Root>');
+
+    act(() =>
+      ReactDOM.render(
+        <Root includeDirect={false} includeIndirect={false} />,
+        container
+      )
+    );
+    expect(store).toMatchSnapshot('7: update to remove both');
+
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('8: components owned by <Root>');
+  });
+
+  it('should show the proper owners list ordering after reordered children', () => {
+    const Root = ({ ascending }) =>
+      ascending
+        ? [<Leaf key="A" />, <Leaf key="B" />, <Leaf key="C" />]
+        : [<Leaf key="C" />, <Leaf key="B" />, <Leaf key="A" />];
+    const Leaf = () => <div>Leaf</div>;
+
+    const container = document.createElement('div');
+    act(() => ReactDOM.render(<Root ascending={true} />, container));
+    expect(store).toMatchSnapshot('1: mount (ascending)');
+
+    const rootID = store.getElementIDAtIndex(0);
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('2: components owned by <Root>');
+
+    act(() => ReactDOM.render(<Root ascending={false} />, container));
+    expect(store).toMatchSnapshot('3: update (descending)');
+
+    expect(
+      printOwnersList(store.getOwnersListForElement(rootID))
+    ).toMatchSnapshot('4: components owned by <Root>');
   });
 });

--- a/src/__tests__/storeSerializer.js
+++ b/src/__tests__/storeSerializer.js
@@ -1,9 +1,74 @@
 import Store from 'src/devtools/store';
 
-export function test(value) {
-  return value instanceof Store;
+// test() is part of Jest's serializer API
+export function test(maybeStore) {
+  return maybeStore instanceof Store;
 }
 
-export function print(value, serialize, indent) {
-  return value.__toSnapshot();
+// print() is part of Jest's serializer API
+export function print(store, serialize, indent) {
+  return printStore(store);
+}
+
+export function printElement(element, includeWeight = false) {
+  let prefix = ' ';
+  if (element.children.length > 0) {
+    prefix = element.isCollapsed ? '▸' : '▾';
+  }
+
+  let key = '';
+  if (element.key !== null) {
+    key = ` key="${element.key}"`;
+  }
+
+  let suffix = '';
+  if (includeWeight) {
+    suffix = ` (${element.isCollapsed ? 1 : element.weight})`;
+  }
+
+  return `${'  '.repeat(element.depth + 1)}${prefix} <${element.displayName ||
+    'null'}${key}>${suffix}`;
+}
+
+export function printOwnersList(elements, includeWeight = false) {
+  return elements
+    .map(element => printElement(element, includeWeight))
+    .join('\n');
+}
+
+// Used for Jest snapshot testing.
+// May also be useful for visually debugging the tree, so it lives on the Store.
+export function printStore(store, includeWeight = false) {
+  const snapshotLines = [];
+
+  let rootWeight = 0;
+
+  store.roots.forEach(rootID => {
+    const { weight } = store.getElementByID(rootID);
+
+    snapshotLines.push('[root]' + (includeWeight ? ` (${weight})` : ''));
+
+    for (let i = rootWeight; i < rootWeight + weight; i++) {
+      const element = store.getElementAtIndex(i);
+
+      if (element == null) {
+        throw Error(`Could not find element at index ${i}`);
+      }
+
+      snapshotLines.push(printElement(element, includeWeight));
+    }
+
+    rootWeight += weight;
+  });
+
+  // Make sure the pretty-printed test align with the Store's reported number of total rows.
+  if (rootWeight !== store.numElements) {
+    throw Error(
+      `Inconsistent Store state. Individual root weights (${rootWeight}) do not match total weight (${
+        store.numElements
+      })`
+    );
+  }
+
+  return snapshotLines.join('\n');
 }

--- a/src/devtools/views/Components/Element.js
+++ b/src/devtools/views/Components/Element.js
@@ -29,17 +29,14 @@ type Props = {
 
 export default function ElementView({ data, index, style }: Props) {
   const store = useContext(StoreContext);
-  const {
-    baseDepth,
-    ownerFlatTree,
-    ownerStack,
-    selectedElementID,
-  } = useContext(TreeStateContext);
+  const { ownerFlatTree, ownerStack, selectedElementID } = useContext(
+    TreeStateContext
+  );
   const dispatch = useContext(TreeDispatcherContext);
 
   const element =
     ownerFlatTree !== null
-      ? store.getElementByID(ownerFlatTree[index])
+      ? ownerFlatTree[index]
       : store.getElementAtIndex(index);
 
   const [isHovered, setIsHovered] = useState(false);
@@ -158,7 +155,7 @@ export default function ElementView({ data, index, style }: Props) {
         ...style, // "style" comes from react-window
 
         // Left padding presents the appearance of a nested tree structure.
-        paddingLeft: `${(depth - baseDepth) * 0.75 + 0.25}rem`,
+        paddingLeft: `${depth * 0.75 + 0.25}rem`,
 
         // These style overrides enable the background color to fill the full visible width,
         // when combined with the CSS tweaks in Tree.

--- a/src/devtools/views/Components/Tree.js
+++ b/src/devtools/views/Components/Tree.js
@@ -22,7 +22,6 @@ import SearchInput from './SearchInput';
 import styles from './Tree.css';
 
 export type ItemData = {|
-  baseDepth: number,
   numElements: number,
   isNavigatingWithKeyboard: boolean,
   lastScrolledIDRef: { current: number | null },
@@ -35,7 +34,6 @@ type Props = {||};
 export default function Tree(props: Props) {
   const dispatch = useContext(TreeDispatcherContext);
   const {
-    baseDepth,
     numElements,
     ownerStack,
     searchIndex,
@@ -255,7 +253,6 @@ export default function Tree(props: Props) {
   // This includes the owner context, since it controls a filtered view of the tree.
   const itemData = useMemo<ItemData>(
     () => ({
-      baseDepth,
       numElements,
       isNavigatingWithKeyboard,
       onElementMouseEnter: handleElementMouseEnter,
@@ -263,7 +260,6 @@ export default function Tree(props: Props) {
       treeFocused,
     }),
     [
-      baseDepth,
       numElements,
       isNavigatingWithKeyboard,
       handleElementMouseEnter,


### PR DESCRIPTION
Resolves #222

- [x] Moved owners list calculations into the `Store`.
- [x] Added snapshot tests.
- [x] Fixed original indirection bug.
- [x] Added an owners `Map` to the store so we don't have to recurse the full subtree to calculate the list.