### PR TITLE
Transfer strings in a string table

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -27,7 +27,7 @@ It consists of:
 1. the total length of next items that belong to string table
 2. for each string in a table:
   1. encoded size
-  2. a list of its codepoints
+  2. a list of its UTF encoded codepoints
 
 For example, for `Foo` and `Bar` we would see:
 

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -592,7 +592,6 @@ export function attach(
   let pendingOperationsQueue: Array<Uint32Array> | null = [];
   let pendingStringTable: Map<string, number> = new Map();
   let pendingStringTableLength = 0;
-  let pendingStringTableCounter = 0;
 
   function pushOperation(op: number): void {
     if (__DEV__) {
@@ -690,7 +689,6 @@ export function attach(
     pendingSimulatedUnmountedIDs.length = 0;
     pendingStringTable.clear();
     pendingStringTableLength = 0;
-    pendingStringTableCounter = 0;
   }
 
   function getStringID(str: string | null): number {
@@ -701,7 +699,7 @@ export function attach(
     if (existingID !== undefined) {
       return existingID;
     }
-    let id = ++pendingStringTableCounter;
+    const id = pendingStringTable.size + 1;
     pendingStringTable.set(str, id);
     // The string table total length needs to account
     // both for the string length, and for the array item

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -630,6 +630,22 @@ export default class Store extends EventEmitter {
     // We'll use the parent ID to adjust selection if it gets deleted.
 
     let i = 2;
+
+    // Reassemble the string table.
+    let stringTable = [
+      null, // ID = 0 corresponds to the null string.
+    ];
+    const stringTableSize = operations[i++];
+    const stringTableEnd = i + stringTableSize;
+    while (i < stringTableEnd) {
+      let nextLength = operations[i++];
+      let nextString = utfDecodeString(
+        (operations.slice(i, i + nextLength): any)
+      );
+      stringTable.push(nextString);
+      i += nextLength;
+    }
+
     while (i < operations.length) {
       const operation = operations[i];
       switch (operation) {
@@ -686,23 +702,13 @@ export default class Store extends EventEmitter {
             ownerID = ((operations[i]: any): number);
             i++;
 
-            const displayNameLength = operations[i];
+            const displayNameStringID = operations[i];
+            const displayName = stringTable[displayNameStringID];
             i++;
-            const displayName =
-              displayNameLength === 0
-                ? null
-                : utfDecodeString(
-                    (operations.slice(i, i + displayNameLength): any)
-                  );
-            i += displayNameLength;
 
-            const keyLength = operations[i];
+            const keyStringID = operations[i];
+            const key = stringTable[keyStringID];
             i++;
-            const key =
-              keyLength === 0
-                ? null
-                : utfDecodeString((operations.slice(i, i + keyLength): any));
-            i += +keyLength;
 
             if (__DEBUG__) {
               debug(

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -632,14 +632,14 @@ export default class Store extends EventEmitter {
     let i = 2;
 
     // Reassemble the string table.
-    let stringTable = [
+    const stringTable = [
       null, // ID = 0 corresponds to the null string.
     ];
     const stringTableSize = operations[i++];
     const stringTableEnd = i + stringTableSize;
     while (i < stringTableEnd) {
-      let nextLength = operations[i++];
-      let nextString = utfDecodeString(
+      const nextLength = operations[i++];
+      const nextString = utfDecodeString(
         (operations.slice(i, i + nextLength): any)
       );
       stringTable.push(nextString);

--- a/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -169,14 +169,14 @@ function updateTree(
   let i = 2;
 
   // Reassemble the string table.
-  let stringTable = [
+  const stringTable = [
     null, // ID = 0 corresponds to the null string.
   ];
   const stringTableSize = operations[i++];
   const stringTableEnd = i + stringTableSize;
   while (i < stringTableEnd) {
-    let nextLength = operations[i++];
-    let nextString = utfDecodeString(
+    const nextLength = operations[i++];
+    const nextString = utfDecodeString(
       (operations.slice(i, i + nextLength): any)
     );
     stringTable.push(nextString);

--- a/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -167,6 +167,22 @@ function updateTree(
   };
 
   let i = 2;
+
+  // Reassemble the string table.
+  let stringTable = [
+    null, // ID = 0 corresponds to the null string.
+  ];
+  const stringTableSize = operations[i++];
+  const stringTableEnd = i + stringTableSize;
+  while (i < stringTableEnd) {
+    let nextLength = operations[i++];
+    let nextString = utfDecodeString(
+      (operations.slice(i, i + nextLength): any)
+    );
+    stringTable.push(nextString);
+    i += nextLength;
+  }
+
   while (i < operations.length) {
     const operation = operations[i];
 
@@ -209,23 +225,13 @@ function updateTree(
 
           i++; // ownerID
 
-          const displayNameLength = operations[i];
+          const displayNameStringID = operations[i];
+          const displayName = stringTable[displayNameStringID];
           i++;
-          const displayName =
-            displayNameLength === 0
-              ? null
-              : utfDecodeString(
-                  (operations.slice(i, i + displayNameLength): any)
-                );
-          i += displayNameLength;
 
-          const keyLength = operations[i];
+          const keyStringID = operations[i];
+          const key = stringTable[keyStringID];
           i++;
-          const key =
-            keyLength === 0
-              ? null
-              : utfDecodeString((operations.slice(i, i + keyLength): any));
-          i += +keyLength;
 
           if (__DEBUG__) {
             debug(


### PR DESCRIPTION
When a large tree mounts or updates, in most cases strings are repetitive. For example, when interacting with a real complex app, I'm seeing how in every batch of `operations`, only ~10% of displayNames/keys are unique. The other ~90% are the same names that we encode multiple times. In the past, we've optimized encoding them to be cached. However, decoding is still lazy. It turns out that **decoding repetitive strings accounts for 40% of time spend in Store's `operations` handler**.

This fixes it with a string table. Individual events like `ADD` no longer contain the encoded strings. Instead, each batch of `operations` contains a list of unique strings in the beginning, and then further operations mention them by ID. I updated the `OVERVIEW` to explain the new format.

## Synthetic results

**Before:** 40ms in renderer, 61ms in the store
**After:** 30ms in renderer, 34ms in the store

## Product code results

**Before:** 109ms in renderer, 246ms in the store
**After:** 108ms in renderer, 150ms in the store
