### PR TITLE
Fix for 'Attempting to use a disconnected port object'

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -5,6 +5,7 @@ declare module 'events' {
     addListener: (type: string, fn: Function) => void;
     emit: (type: string, data: any) => void;
     removeListener: (type: string, fn: Function) => void;
+    removeAllListeners: (type?: string) => void;
   }
 
   declare export default typeof EventEmitter;

--- a/shells/dev/src/backend.js
+++ b/shells/dev/src/backend.js
@@ -7,9 +7,13 @@ import { initBackend } from 'src/backend';
 
 const bridge = new Bridge({
   listen(fn) {
-    window.addEventListener('message', event => {
+    const listener = event => {
       fn(event.data);
-    });
+    };
+    window.addEventListener('message', listener);
+    return () => {
+      window.removeEventListener('message', listener);
+    };
   },
   send(event: string, payload: any, transferable?: Array<any>) {
     window.parent.postMessage({ event, payload }, '*', transferable);

--- a/shells/dev/src/devtools.js
+++ b/shells/dev/src/devtools.js
@@ -43,9 +43,15 @@ inject('./build/app.js', () => {
     connect(cb) {
       const bridge = new Bridge({
         listen(fn) {
-          contentWindow.parent.addEventListener('message', ({ data }) => {
+          const listener = ({ data }) => {
             fn(data);
-          });
+          };
+          // Preserve the reference to the window we subscribe to, so we can unsubscribe from it when required.
+          const contentWindowParent = contentWindow.parent;
+          contentWindowParent.addEventListener('message', listener);
+          return () => {
+            contentWindowParent.removeEventListener('message', listener);
+          };
         },
         send(event: string, payload: any, transferable?: Array<any>) {
           contentWindow.postMessage({ event, payload }, '*', transferable);

--- a/src/__tests__/setupTests.js
+++ b/src/__tests__/setupTests.js
@@ -28,10 +28,15 @@ env.beforeEach(() => {
   installHook(global);
 
   const bridgeListeners = [];
-
   const bridge = new Bridge({
     listen(callback) {
       bridgeListeners.push(callback);
+      return () => {
+        const index = bridgeListeners.indexOf(callback);
+        if (index >= 0) {
+          bridgeListeners.splice(index, 1);
+        }
+      };
     },
     send(event: string, payload: any, transferable?: Array<any>) {
       bridgeListeners.forEach(callback => callback({ event, payload }));

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ export type Bridge = {
 };
 
 export type Wall = {|
-  listen: (fn: Function) => void,
+  // `listen` returns the "unlisten" function.
+  listen: (fn: Function) => Function,
   send: (event: string, payload: any, transferable?: Array<any>) => void,
 |};


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-devtools-experimental/issues/217

The error reproduces with any two React websites, e.g. `https://reactjs.org` and `https://nextjs.org`, by keeping the DevTools Components tab open and switching between these websites in the same browser tab.

There are several issues with the code that contribute to this:
1. `Bridge` leaves behind a dangling timer that fires `_flush` after the bridge has been abandoned ("shutdown").
2. `bridge.send('shutdown')` is asynchronous, so the event handlers do not get unsubscribed in time.
3. `port.onDisconnect` does not trigger on in-tab navigation like new URL or back/forward navigation.
4. State management design of the code that uses shared variables and callbacks makes it hard to handle race conditions originating from the browser.

This commit cleans up some of the lacking symmetry when using `addListener`/`removeListener`, but the code in `shells/browser/shared/src/main.js` is hard to reason about with regards to race conditions, and there are many possible race conditions originating from the browser, so maybe there could be a better design paradigm (like a formal state machine) to manage the state changes in response to sequences of events than plain old event listeners, callbacks, and shared variables.

Unrelated, but clicking Chrome Back/Forward/Back/Forward very fast makes the browser and the DevTools and the DevTools of DevTools stall and become unresponsive for some time, then recovers but the Back/Forward/Stop/Refresh button and favicon loading indicator may remain broken. Looks like a Chrome bug, some kind of a temporary deadlock in handling the browser history.
