### PR TITLE
Start using @babel/preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "plugins": [
-    ["@babel/plugin-transform-flow-strip-types"],
-    ["@babel/plugin-proposal-class-properties", { "loose": false }]
-  ],
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-flow"]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,39 @@
+const chromeManifest = require('./shells/browser/chrome/manifest.json');
+const firefoxManifest = require('./shells/browser/firefox/manifest.json');
+
+const minChromeVersion = parseInt(chromeManifest.minimum_chrome_version, 10);
+const minFirefoxVersion = parseInt(
+  firefoxManifest.applications.gecko.strict_min_version,
+  10
+);
+validateVersion(minChromeVersion);
+validateVersion(minFirefoxVersion);
+
+function validateVersion(version) {
+  if (version > 0 && version < 200) {
+    return;
+  }
+  throw new Error('Suspicious browser version in manifest: ' + version);
+}
+
+module.exports = api => {
+  const isTest = api.env('test');
+  const targets = {};
+  if (isTest) {
+    targets.node = 'current';
+  } else {
+    targets.chrome = minChromeVersion.toString();
+    targets.firefox = minFirefoxVersion.toString();
+  }
+  return {
+    plugins: [
+      ['@babel/plugin-transform-flow-strip-types'],
+      ['@babel/plugin-proposal-class-properties', { loose: false }],
+    ],
+    presets: [
+      ['@babel/preset-env', { targets }],
+      '@babel/preset-react',
+      '@babel/preset-flow',
+    ],
+  };
+};

--- a/shells/browser/shared/webpack.backend.js
+++ b/shells/browser/shared/webpack.backend.js
@@ -1,4 +1,3 @@
-const { readFileSync } = require('fs');
 const { resolve } = require('path');
 const { DefinePlugin } = require('webpack');
 const { getGitHubURL, getVersionString } = require('../../utils');
@@ -41,9 +40,9 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        options: JSON.parse(
-          readFileSync(resolve(__dirname, '../../../.babelrc'))
-        ),
+        options: {
+          configFile: resolve(__dirname, '../../../babel.config.js'),
+        },
       },
     ],
   },

--- a/shells/browser/shared/webpack.config.js
+++ b/shells/browser/shared/webpack.config.js
@@ -1,4 +1,3 @@
-const { readFileSync } = require('fs');
 const { resolve } = require('path');
 const { DefinePlugin } = require('webpack');
 const { getGitHubURL, getVersionString } = require('../../utils');
@@ -47,9 +46,9 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        options: JSON.parse(
-          readFileSync(resolve(__dirname, '../../../.babelrc'))
-        ),
+        options: {
+          configFile: resolve(__dirname, '../../../babel.config.js'),
+        },
       },
       {
         test: /\.css$/,

--- a/shells/dev/webpack.config.js
+++ b/shells/dev/webpack.config.js
@@ -1,4 +1,3 @@
-const { readFileSync } = require('fs');
 const { resolve } = require('path');
 const { DefinePlugin } = require('webpack');
 const { getGitHubURL, getVersionString } = require('../utils');
@@ -43,7 +42,9 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        options: JSON.parse(readFileSync(resolve(__dirname, '../../.babelrc'))),
+        options: {
+          configFile: require.resolve('../../babel.config.js'),
+        },
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
I noticed our tests include regenerator transform which messes up the stack traces. As I was looking into why we have it, I realized we're not actually using `preset-env`. We didn't specify any targets so it behaves identically to `es2015`.

This changes our Babel config to actually use `preset-env`:

* For tests, we use the current Node environment.
* For the extension, we specify `chrome` and `firefox` versions from the respective manifest. I use an intersection to reduce the number of possible combinations.

Even that gives us a lot of ES6 syntax untranspiled. For example, `onBridgeOperations` no longer has an inner closure because it can use normal `let` / `const`.

<img width="607" alt="Screen Shot 2019-04-26 at 7 33 17 PM" src="https://user-images.githubusercontent.com/810438/56828882-33634580-685a-11e9-8c33-1a4b9a7fe92b.png">

And tests don't use regenerator now which will give us clearer failures.