### PR TITLE
Remove Agent addBridge: there can only be one bridge, add in constructor

### DIFF
--- a/shells/browser/shared/src/backend.js
+++ b/shells/browser/shared/src/backend.js
@@ -54,8 +54,7 @@ function setup(hook) {
     },
   });
 
-  const agent = new Agent();
-  agent.addBridge(bridge);
+  const agent = new Agent(bridge);
   agent.addListener('shutdown', () => {
     hook.emit('shutdown');
     listeners.forEach(fn => {

--- a/shells/dev/src/backend.js
+++ b/shells/dev/src/backend.js
@@ -25,7 +25,6 @@ bridge.addListener('captureScreenshot', ({ commitIndex }) => {
   });
 });
 
-const agent = new Agent();
-agent.addBridge(bridge);
+const agent = new Agent(bridge);
 
 initBackend(window.__REACT_DEVTOOLS_GLOBAL_HOOK__, agent, window.parent);

--- a/src/__tests__/setupTests.js
+++ b/src/__tests__/setupTests.js
@@ -38,8 +38,7 @@ env.beforeEach(() => {
     },
   });
 
-  const agent = new Agent();
-  agent.addBridge(bridge);
+  const agent = new Agent(bridge);
 
   const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -61,13 +61,13 @@ type PersistedSelection = {|
 |};
 
 export default class Agent extends EventEmitter {
-  _bridge: Bridge = ((null: any): Bridge);
+  _bridge: Bridge;
   _isProfiling: boolean = false;
   _rendererInterfaces: { [key: RendererID]: RendererInterface } = {};
   _persistedSelection: PersistedSelection | null = null;
   _persistedSelectionMatch: PathMatch | null = null;
 
-  constructor() {
+  constructor(bridge: Bridge) {
     super();
 
     if (localStorage.getItem(LOCAL_STORAGE_RELOAD_AND_PROFILE_KEY) === 'true') {
@@ -84,9 +84,7 @@ export default class Agent extends EventEmitter {
         this._persistedSelection = JSON.parse(persistedSelectionString);
       }
     }
-  }
 
-  addBridge(bridge: Bridge) {
     this._bridge = bridge;
 
     bridge.addListener('captureScreenshot', this.captureScreenshot);
@@ -123,7 +121,7 @@ export default class Agent extends EventEmitter {
     bridge.addListener('viewElementSource', this.viewElementSource);
 
     if (this._isProfiling) {
-      this._bridge.send('profilingStatus', true);
+      bridge.send('profilingStatus', true);
     }
   }
 


### PR DESCRIPTION
Let's make impossible states truly impossible, and fix Flow types, too.

All three usages of Agent called addBridge right after constructing it.
Agent has one field `_bridge` which is force-typed as not-null despite
there's a temporary zone between the constructor end and addBridge start
where `_bridge` is null.