### PR TITLE
Cleanup profile export/import data types, add basic tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ shells/browser/firefox/build
 shells/browser/shared/build
 shells/dev/dist
 vendor
+*.js.snap
 
 package-lock.json
 yarn.lock

--- a/src/__tests__/__snapshots__/profiling-test.js.snap
+++ b/src/__tests__/__snapshots__/profiling-test.js.snap
@@ -78,81 +78,74 @@ Object {
 }
 `;
 
-exports[`profiling CommitDetails should be collected for each commit: exported data 1`] = `
+exports[`profiling CommitDetails should be collected for each commit: imported data 1`] = `
 Object {
   "commitDetails": Array [
     Object {
+      "actualDurations": Map {
+        1 => 12,
+        2 => 12,
+        3 => 0,
+        4 => 1,
+        5 => 1,
+      },
       "commitIndex": 0,
-      "durations": Array [
-        1,
-        12,
-        0,
-        2,
-        12,
-        10,
-        3,
-        0,
-        0,
-        4,
-        1,
-        1,
-        5,
-        1,
-        1,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        1 => 0,
+        2 => 10,
+        3 => 0,
+        4 => 1,
+        5 => 1,
+      },
     },
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        4 => 1,
+        6 => 2,
+        2 => 13,
+        1 => 13,
+      },
       "commitIndex": 1,
-      "durations": Array [
-        3,
-        0,
-        0,
-        4,
-        1,
-        1,
-        6,
-        2,
-        2,
-        2,
-        13,
-        10,
-        1,
-        13,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        4 => 1,
+        6 => 2,
+        2 => 10,
+        1 => 0,
+      },
     },
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        2 => 10,
+        1 => 10,
+      },
       "commitIndex": 2,
-      "durations": Array [
-        3,
-        0,
-        0,
-        2,
-        10,
-        10,
-        1,
-        10,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        2 => 10,
+        1 => 0,
+      },
     },
     Object {
+      "actualDurations": Map {
+        2 => 10,
+        1 => 10,
+      },
       "commitIndex": 3,
-      "durations": Array [
-        2,
-        10,
-        10,
-        1,
-        10,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        2 => 10,
+        1 => 0,
+      },
     },
   ],
   "interactions": Object {
@@ -161,7 +154,7 @@ Object {
   },
   "profilingOperations": Map {
     1 => Array [
-      Array [
+      Uint32Array [
         1,
         1,
         17,
@@ -231,7 +224,7 @@ Object {
         5,
         1000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         8,
@@ -267,7 +260,7 @@ Object {
         1,
         14000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         0,
@@ -287,7 +280,7 @@ Object {
         1,
         11000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         0,
@@ -313,7 +306,7 @@ Object {
       35,
       45,
     ],
-    "initialTreeBaseDurations": Array [],
+    "initialTreeBaseDurations": Map {},
     "interactionCount": 0,
     "rootID": 1,
   },
@@ -442,68 +435,61 @@ Object {
 }
 `;
 
-exports[`profiling FiberCommits should be collected for each rendered fiber: exported data 1`] = `
+exports[`profiling FiberCommits should be collected for each rendered fiber: imported data 1`] = `
 Object {
   "commitDetails": Array [
     Object {
+      "actualDurations": Map {
+        1 => 11,
+        2 => 11,
+        3 => 0,
+        4 => 1,
+      },
       "commitIndex": 0,
-      "durations": Array [
-        1,
-        11,
-        0,
-        2,
-        11,
-        10,
-        3,
-        0,
-        0,
-        4,
-        1,
-        1,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        1 => 0,
+        2 => 10,
+        3 => 0,
+        4 => 1,
+      },
     },
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        5 => 1,
+        2 => 11,
+        1 => 11,
+      },
       "commitIndex": 1,
-      "durations": Array [
-        3,
-        0,
-        0,
-        5,
-        1,
-        1,
-        2,
-        11,
-        10,
-        1,
-        11,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        5 => 1,
+        2 => 10,
+        1 => 0,
+      },
     },
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        5 => 1,
+        6 => 2,
+        2 => 13,
+        1 => 13,
+      },
       "commitIndex": 2,
-      "durations": Array [
-        3,
-        0,
-        0,
-        5,
-        1,
-        1,
-        6,
-        2,
-        2,
-        2,
-        13,
-        10,
-        1,
-        13,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        5 => 1,
+        6 => 2,
+        2 => 10,
+        1 => 0,
+      },
     },
   ],
   "interactions": Object {
@@ -512,7 +498,7 @@ Object {
   },
   "profilingOperations": Map {
     1 => Array [
-      Array [
+      Uint32Array [
         1,
         1,
         15,
@@ -570,7 +556,7 @@ Object {
         4,
         1000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         8,
@@ -605,7 +591,7 @@ Object {
         1,
         12000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         8,
@@ -657,7 +643,7 @@ Object {
       22,
       35,
     ],
-    "initialTreeBaseDurations": Array [],
+    "initialTreeBaseDurations": Map {},
     "interactionCount": 0,
     "rootID": 1,
   },
@@ -666,47 +652,42 @@ Object {
 `;
 
 exports[`profiling Interactions should be collected for every traced interaction: Interactions 1`] = `
-Array [
-  Object {
-    "__count": 1,
-    "commits": Array [
-      0,
-    ],
-    "id": 0,
-    "name": "mount: one child",
-    "timestamp": 0,
-  },
-  Object {
-    "__count": 0,
-    "commits": Array [
-      1,
-    ],
-    "id": 1,
-    "name": "update: two children",
-    "timestamp": 11,
-  },
-]
+Object {
+  "interactions": Array [
+    Object {
+      "__count": 1,
+      "commits": Array [
+        0,
+      ],
+      "id": 0,
+      "name": "mount: one child",
+      "timestamp": 0,
+    },
+    Object {
+      "__count": 0,
+      "commits": Array [
+        1,
+      ],
+      "id": 1,
+      "name": "update: two children",
+      "timestamp": 11,
+    },
+  ],
+  "rootID": 1,
+}
 `;
 
-exports[`profiling Interactions should be collected for every traced interaction: exported data 1`] = `
+exports[`profiling Interactions should be collected for every traced interaction: imported data 1`] = `
 Object {
   "commitDetails": Array [
     Object {
+      "actualDurations": Map {
+        1 => 11,
+        2 => 11,
+        3 => 0,
+        4 => 1,
+      },
       "commitIndex": 0,
-      "durations": Array [
-        1,
-        11,
-        0,
-        2,
-        11,
-        10,
-        3,
-        0,
-        0,
-        4,
-        1,
-        1,
-      ],
       "interactions": Array [
         Object {
           "__count": 1,
@@ -716,23 +697,21 @@ Object {
         },
       ],
       "rootID": 1,
+      "selfDurations": Map {
+        1 => 0,
+        2 => 10,
+        3 => 0,
+        4 => 1,
+      },
     },
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        5 => 1,
+        2 => 11,
+        1 => 11,
+      },
       "commitIndex": 1,
-      "durations": Array [
-        3,
-        0,
-        0,
-        5,
-        1,
-        1,
-        2,
-        11,
-        10,
-        1,
-        11,
-        0,
-      ],
       "interactions": Array [
         Object {
           "__count": 0,
@@ -742,6 +721,12 @@ Object {
         },
       ],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        5 => 1,
+        2 => 10,
+        1 => 0,
+      },
     },
   ],
   "interactions": Object {
@@ -769,7 +754,7 @@ Object {
   },
   "profilingOperations": Map {
     1 => Array [
-      Array [
+      Uint32Array [
         1,
         1,
         15,
@@ -827,7 +812,7 @@ Object {
         4,
         1000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         8,
@@ -876,7 +861,7 @@ Object {
       11,
       22,
     ],
-    "initialTreeBaseDurations": Array [],
+    "initialTreeBaseDurations": Map {},
     "interactionCount": 2,
     "rootID": 1,
   },
@@ -908,59 +893,55 @@ Object {
 }
 `;
 
-exports[`profiling ProfilingSummary should be collected for each commit: exported data 1`] = `
+exports[`profiling ProfilingSummary should be collected for each commit: imported data 1`] = `
 Object {
   "commitDetails": Array [
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        4 => 1,
+        6 => 2,
+        2 => 13,
+        1 => 13,
+      },
       "commitIndex": 0,
-      "durations": Array [
-        3,
-        0,
-        0,
-        4,
-        1,
-        1,
-        6,
-        2,
-        2,
-        2,
-        13,
-        10,
-        1,
-        13,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        4 => 1,
+        6 => 2,
+        2 => 10,
+        1 => 0,
+      },
     },
     Object {
+      "actualDurations": Map {
+        3 => 0,
+        2 => 10,
+        1 => 10,
+      },
       "commitIndex": 1,
-      "durations": Array [
-        3,
-        0,
-        0,
-        2,
-        10,
-        10,
-        1,
-        10,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        3 => 0,
+        2 => 10,
+        1 => 0,
+      },
     },
     Object {
+      "actualDurations": Map {
+        2 => 10,
+        1 => 10,
+      },
       "commitIndex": 2,
-      "durations": Array [
-        2,
-        10,
-        10,
-        1,
-        10,
-        0,
-      ],
       "interactions": Array [],
       "rootID": 1,
+      "selfDurations": Map {
+        2 => 10,
+        1 => 0,
+      },
     },
   ],
   "interactions": Object {
@@ -969,7 +950,7 @@ Object {
   },
   "profilingOperations": Map {
     1 => Array [
-      Array [
+      Uint32Array [
         1,
         1,
         8,
@@ -1005,7 +986,7 @@ Object {
         1,
         14000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         0,
@@ -1025,7 +1006,7 @@ Object {
         1,
         11000,
       ],
-      Array [
+      Uint32Array [
         1,
         1,
         0,
@@ -1091,18 +1072,13 @@ Object {
       23,
       33,
     ],
-    "initialTreeBaseDurations": Array [
-      1,
-      12,
-      2,
-      12,
-      3,
-      0,
-      4,
-      1,
-      5,
-      1,
-    ],
+    "initialTreeBaseDurations": Map {
+      1 => 12,
+      2 => 12,
+      3 => 0,
+      4 => 1,
+      5 => 1,
+    },
     "interactionCount": 0,
     "rootID": 1,
   },

--- a/src/__tests__/profilingCharts-test.js
+++ b/src/__tests__/profilingCharts-test.js
@@ -253,7 +253,7 @@ describe('profiling charts', () => {
           rendererID,
           rootID,
         });
-        const interactions = store.profilingCache.Interactions.read({
+        const { interactions } = store.profilingCache.Interactions.read({
           rendererID,
           rootID,
         });

--- a/src/__tests__/setupTests.js
+++ b/src/__tests__/setupTests.js
@@ -31,31 +31,43 @@ env.beforeEach(() => {
 
   installHook(global);
 
-  const bridgeListeners = [];
-  const bridge = new Bridge({
-    listen(callback) {
-      bridgeListeners.push(callback);
-      return () => {
-        const index = bridgeListeners.indexOf(callback);
-        if (index >= 0) {
-          bridgeListeners.splice(index, 1);
-        }
-      };
-    },
-    send(event: string, payload: any, transferable?: Array<any>) {
-      bridgeListeners.forEach(callback => callback({ event, payload }));
-    },
-  });
+  function init() {
+    const bridgeListeners = [];
+    const bridge = new Bridge({
+      listen(callback) {
+        bridgeListeners.push(callback);
+        return () => {
+          const index = bridgeListeners.indexOf(callback);
+          if (index >= 0) {
+            bridgeListeners.splice(index, 1);
+          }
+        };
+      },
+      send(event: string, payload: any, transferable?: Array<any>) {
+        bridgeListeners.forEach(callback => callback({ event, payload }));
+      },
+    });
 
-  const agent = new Agent(bridge);
+    const agent = new Agent(bridge);
 
-  const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 
-  initBackend(hook, agent, global);
+    const destroyBackend = initBackend(hook, agent, global);
 
-  global.agent = agent;
-  global.bridge = bridge;
-  global.store = new Store(bridge);
+    const store = new Store(bridge);
+
+    global.agent = agent;
+    global.bridge = bridge;
+    global.store = store;
+
+    // Reinit may be used to reset the store and the bridge during a test.
+    global.reinit = () => {
+      destroyBackend();
+      init();
+    };
+  }
+
+  init();
 });
 env.afterEach(() => {
   delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -9,7 +9,7 @@ export function initBackend(
   hook: DevToolsHook,
   agent: Agent,
   global: Object
-): void {
+): () => void {
   const subs = [
     hook.sub(
       'renderer-attached',
@@ -60,20 +60,30 @@ export function initBackend(
   });
 
   // Connect any new renderers that injected themselves.
-  hook.on(
-    'renderer',
-    ({ id, renderer }: { id: number, renderer: ReactRenderer }) => {
-      attachRenderer(id, renderer);
-    }
+  subs.push(
+    hook.sub(
+      'renderer',
+      ({ id, renderer }: { id: number, renderer: ReactRenderer }) => {
+        attachRenderer(id, renderer);
+      }
+    )
   );
 
   hook.emit('react-devtools', agent);
   hook.reactDevtoolsAgent = agent;
-  agent.addListener('shutdown', () => {
+  const onAgentShutdown = () => {
     subs.forEach(fn => fn());
     hook.rendererInterfaces.forEach(rendererInterface => {
       rendererInterface.cleanup();
     });
     hook.reactDevtoolsAgent = null;
+  };
+  agent.addListener('shutdown', onAgentShutdown);
+  subs.push(() => {
+    agent.removeListener('shutdown', onAgentShutdown);
   });
+
+  return () => {
+    subs.forEach(fn => fn());
+  };
 }

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -123,7 +123,7 @@ export type InteractionBackend = {|
 
 export type CommitDetailsBackend = {|
   commitIndex: number,
-  // Tuple of id, actual duration, and (computed) self duration
+  // An interleaved array: fiberID at [i], actualDuration at [i + 1], computed selfDuration at [i + 2].
   durations: Array<number>,
   interactions: Array<InteractionBackend>,
   rootID: number,
@@ -148,9 +148,17 @@ export type InteractionsBackend = {|
 export type ProfilingSummaryBackend = {|
   commitDurations: Array<number>,
   commitTimes: Array<number>,
+  // An interleaved array: fiberID at [i], initialTreeBaseDuration at [i + 1].
   initialTreeBaseDurations: Array<number>,
   interactionCount: number,
   rootID: number,
+|};
+
+export type ExportedProfilingDataFromRenderer = {|
+  version: 3,
+  profilingSummary: ProfilingSummaryBackend,
+  commitDetails: Array<CommitDetailsBackend>,
+  interactions: InteractionsBackend,
 |};
 
 export type PathFrame = {|
@@ -180,7 +188,9 @@ export type RendererInterface = {
   getFiberCommits: (rootID: number, fiberID: number) => FiberCommitsBackend,
   getInteractions: (rootID: number) => InteractionsBackend,
   getOwnersList: (id: number) => Array<Owner> | null,
-  getProfilingDataForDownload: (rootID: number) => Object,
+  getExportedProfilingData: (
+    rootID: number
+  ) => ExportedProfilingDataFromRenderer,
   getProfilingSummary: (rootID: number) => ProfilingSummaryBackend,
   getPathForElement: (id: number) => Array<PathFrame> | null,
   handleCommitFiberRoot: (fiber: Object) => void,

--- a/src/devtools/ProfilingCache.js
+++ b/src/devtools/ProfilingCache.js
@@ -20,7 +20,6 @@ import {
 } from 'src/devtools/views/Profiler/RankedChartBuilder';
 
 import type { Resource } from './cache';
-import type { Bridge } from '../types';
 import type {
   CommitDetailsBackend,
   FiberCommitsBackend,
@@ -38,6 +37,7 @@ import type {
 import type { ChartData as FlamegraphChartData } from 'src/devtools/views/Profiler/FlamegraphChartBuilder';
 import type { ChartData as InteractionsChartData } from 'src/devtools/views/Profiler/InteractionsChartBuilder';
 import type { ChartData as RankedChartData } from 'src/devtools/views/Profiler/RankedChartBuilder';
+import type { Bridge } from 'src/types';
 
 type CommitDetailsParams = {|
   commitIndex: number,
@@ -97,23 +97,24 @@ export default class ProfilingCache {
   > = createResource(
     ({ commitIndex, rendererID, rootID }: CommitDetailsParams) => {
       return new Promise(resolve => {
+        const pendingKey = `${rootID}-${commitIndex}`;
         const importedProfilingData = this._store.importedProfilingData;
         if (importedProfilingData !== null) {
-          const { commitDetails } = (importedProfilingData: any);
-          if (commitDetails != null && commitIndex < commitDetails.length) {
-            const response = commitDetails[commitIndex];
-            this._pendingCommitDetailsMap.set(
-              `${response.rootID}-${commitIndex}`,
-              resolve
-            );
-            this.onCommitDetails(response);
-            return;
+          const commitDetailsByCommitIndex =
+            importedProfilingData.commitDetails;
+          if (
+            commitDetailsByCommitIndex != null &&
+            commitIndex < commitDetailsByCommitIndex.length
+          ) {
+            const commitDetails = commitDetailsByCommitIndex[commitIndex];
+            if (commitDetails != null) {
+              this._pendingCommitDetailsMap.delete(pendingKey);
+              resolve(commitDetails);
+              return;
+            }
           }
         } else if (this._store.profilingOperations.has(rootID)) {
-          this._pendingCommitDetailsMap.set(
-            `${rootID}-${commitIndex}`,
-            resolve
-          );
+          this._pendingCommitDetailsMap.set(pendingKey, resolve);
           this._bridge.send('getCommitDetails', {
             commitIndex,
             rendererID,
@@ -123,6 +124,7 @@ export default class ProfilingCache {
         }
 
         // If no profiling data was recorded for this root, skip the round trip.
+        this._pendingCommitDetailsMap.delete(pendingKey);
         resolve({
           rootID,
           commitIndex,
@@ -143,29 +145,27 @@ export default class ProfilingCache {
   > = createResource(
     ({ fiberID, rendererID, rootID }: FiberCommitsParams) => {
       return new Promise(resolve => {
+        const pendingKey = `${rootID}-${fiberID}`;
         const importedProfilingData = this._store.importedProfilingData;
         if (importedProfilingData !== null) {
-          const { commitDetails } = (importedProfilingData: any);
-          if (commitDetails != null) {
-            const commitDurations = [];
-            commitDetails.forEach(({ durations }, commitIndex) => {
-              for (let i = 0; i < durations.length; i += 3) {
-                if (durations[i] === fiberID) {
-                  commitDurations.push(commitIndex, durations[i + 2]);
-                  break;
-                }
-              }
-            });
-            this._pendingFiberCommitsMap.set(`${rootID}-${fiberID}`, resolve);
-            this.onFiberCommits({
-              commitDurations,
-              fiberID,
-              rootID,
-            });
-            return;
-          }
+          const { commitDetails } = importedProfilingData;
+          const commitDurations = [];
+          commitDetails.forEach(({ selfDurations }, commitIndex) => {
+            const selfDuration = selfDurations.get(fiberID);
+            if (selfDuration != null) {
+              commitDurations.push(commitIndex, selfDuration);
+            }
+          });
+          const fiberCommitsFrontend: FiberCommitsFrontend = {
+            commitDurations,
+            fiberID,
+            rootID,
+          };
+          this._pendingFiberCommitsMap.delete(pendingKey);
+          resolve(fiberCommitsFrontend);
+          return;
         } else if (this._store.profilingOperations.has(rootID)) {
-          this._pendingFiberCommitsMap.set(`${rootID}-${fiberID}`, resolve);
+          this._pendingFiberCommitsMap.set(pendingKey, resolve);
           this._bridge.send('getFiberCommits', {
             fiberID,
             rendererID,
@@ -175,11 +175,13 @@ export default class ProfilingCache {
         }
 
         // If no profiling data was recorded for this root, skip the round trip.
-        resolve({
+        this._pendingFiberCommitsMap.delete(pendingKey);
+        const fiberCommitsFrontend: FiberCommitsFrontend = {
           commitDurations: [],
           fiberID,
           rootID,
-        });
+        };
+        resolve(fiberCommitsFrontend);
       });
     },
     ({ fiberID, rendererID, rootID }: FiberCommitsParams) =>
@@ -193,16 +195,18 @@ export default class ProfilingCache {
   > = createResource(
     ({ rendererID, rootID }: InteractionsParams) => {
       return new Promise(resolve => {
+        const pendingKey = rootID;
         const importedProfilingData = this._store.importedProfilingData;
         if (importedProfilingData !== null) {
-          const { interactions } = (importedProfilingData: any);
-          if (interactions != null) {
-            this._pendingInteractionsMap.set(interactions.rootID, resolve);
-            this.onInteractions(interactions);
+          const interactionsFrontend: InteractionsFrontend =
+            importedProfilingData.interactions;
+          if (interactionsFrontend != null) {
+            this._pendingInteractionsMap.delete(pendingKey);
+            resolve(interactionsFrontend);
             return;
           }
         } else if (this._store.profilingOperations.has(rootID)) {
-          this._pendingInteractionsMap.set(rootID, resolve);
+          this._pendingInteractionsMap.set(pendingKey, resolve);
           this._bridge.send('getInteractions', {
             rendererID,
             rootID,
@@ -211,7 +215,12 @@ export default class ProfilingCache {
         }
 
         // If no profiling data was recorded for this root, skip the round trip.
-        resolve([]);
+        this._pendingInteractionsMap.delete(pendingKey);
+        const interactionsFrontend: InteractionsFrontend = {
+          interactions: [],
+          rootID,
+        };
+        resolve(interactionsFrontend);
       });
     },
     ({ rendererID, rootID }: ProfilingSummaryParams) => rootID
@@ -224,31 +233,32 @@ export default class ProfilingCache {
   > = createResource(
     ({ rendererID, rootID }: ProfilingSummaryParams) => {
       return new Promise(resolve => {
+        const pendingKey = rootID;
         const importedProfilingData = this._store.importedProfilingData;
         if (importedProfilingData !== null) {
-          const { profilingSummary } = (importedProfilingData: any);
-          if (profilingSummary != null) {
-            this._pendingProfileSummaryMap.set(
-              profilingSummary.rootID,
-              resolve
-            );
-            this.onProfileSummary(profilingSummary);
+          const profilingSummaryFrontend: ProfilingSummaryFrontend =
+            importedProfilingData.profilingSummary;
+          if (profilingSummaryFrontend != null) {
+            this._pendingProfileSummaryMap.delete(pendingKey);
+            resolve(profilingSummaryFrontend);
             return;
           }
         } else if (this._store.profilingOperations.has(rootID)) {
-          this._pendingProfileSummaryMap.set(rootID, resolve);
+          this._pendingProfileSummaryMap.set(pendingKey, resolve);
           this._bridge.send('getProfilingSummary', { rendererID, rootID });
           return;
         }
 
         // If no profiling data was recorded for this root, skip the round trip.
-        resolve({
+        this._pendingProfileSummaryMap.delete(pendingKey);
+        const profilingSummaryFrontend: ProfilingSummaryFrontend = {
           rootID,
           commitDurations: [],
           commitTimes: [],
           initialTreeBaseDurations: new Map(),
           interactionCount: 0,
-        });
+        };
+        resolve(profilingSummaryFrontend);
       });
     },
     ({ rendererID, rootID }: ProfilingSummaryParams) => rootID
@@ -289,7 +299,6 @@ export default class ProfilingCache {
   getInteractionsChartData = ({
     interactions,
     profilingSummary,
-    rootID,
   }: {|
     interactions: Array<InteractionWithCommitsFrontend>,
     profilingSummary: ProfilingSummaryFrontend,
@@ -328,6 +337,8 @@ export default class ProfilingCache {
     invalidateRankedChartData();
 
     this._pendingCommitDetailsMap.clear();
+    this._pendingFiberCommitsMap.clear();
+    this._pendingInteractionsMap.clear();
     this._pendingProfileSummaryMap.clear();
   }
 
@@ -342,21 +353,23 @@ export default class ProfilingCache {
     if (resolve != null) {
       this._pendingCommitDetailsMap.delete(key);
 
-      const actualDurationsMap = new Map();
-      const selfDurationsMap = new Map();
+      const actualDurationsMap = new Map<number, number>();
+      const selfDurationsMap = new Map<number, number>();
       for (let i = 0; i < durations.length; i += 3) {
-        const id = durations[i];
-        actualDurationsMap.set(id, durations[i + 1]);
-        selfDurationsMap.set(id, durations[i + 2]);
+        const fiberID = durations[i];
+        actualDurationsMap.set(fiberID, durations[i + 1]);
+        selfDurationsMap.set(fiberID, durations[i + 2]);
       }
 
-      resolve({
-        rootID,
-        commitIndex,
-        actualDurations: actualDurationsMap,
-        selfDurations: selfDurationsMap,
-        interactions,
-      });
+      resolve(
+        ({
+          actualDurations: actualDurationsMap,
+          commitIndex,
+          interactions,
+          rootID,
+          selfDurations: selfDurationsMap,
+        }: CommitDetailsFrontend)
+      );
     }
   };
 
@@ -370,11 +383,13 @@ export default class ProfilingCache {
     if (resolve != null) {
       this._pendingFiberCommitsMap.delete(key);
 
-      resolve({
-        commitDurations,
-        fiberID,
-        rootID,
-      });
+      resolve(
+        ({
+          commitDurations,
+          fiberID,
+          rootID,
+        }: FiberCommitsFrontend)
+      );
     }
   };
 
@@ -383,7 +398,12 @@ export default class ProfilingCache {
     if (resolve != null) {
       this._pendingInteractionsMap.delete(rootID);
 
-      resolve(interactions);
+      resolve(
+        ({
+          interactions,
+          rootID,
+        }: InteractionsFrontend)
+      );
     }
   };
 
@@ -400,19 +420,20 @@ export default class ProfilingCache {
 
       const initialTreeBaseDurationsMap = new Map();
       for (let i = 0; i < initialTreeBaseDurations.length; i += 2) {
-        initialTreeBaseDurationsMap.set(
-          initialTreeBaseDurations[i],
-          initialTreeBaseDurations[i + 1]
-        );
+        const fiberID = initialTreeBaseDurations[i];
+        const initialTreeBaseDuration = initialTreeBaseDurations[i + 1];
+        initialTreeBaseDurationsMap.set(fiberID, initialTreeBaseDuration);
       }
 
-      resolve({
-        rootID,
-        commitDurations,
-        commitTimes,
-        initialTreeBaseDurations: initialTreeBaseDurationsMap,
-        interactionCount,
-      });
+      resolve(
+        ({
+          commitDurations,
+          commitTimes,
+          initialTreeBaseDurations: initialTreeBaseDurationsMap,
+          interactionCount,
+          rootID,
+        }: ProfilingSummaryFrontend)
+      );
     }
   };
 }

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -715,13 +715,14 @@ export default class Store extends EventEmitter {
   ) => {
     const element = this.getElementByID(elementID);
     if (element !== null) {
-      profilingSnapshots.set(elementID, {
+      const snapshotNode: ProfilingSnapshotNode = {
         id: elementID,
         children: element.children.slice(0),
         displayName: element.displayName,
         key: element.key,
         type: element.type,
-      });
+      };
+      profilingSnapshots.set(elementID, snapshotNode);
 
       element.children.forEach(childID =>
         this._takeProfilingSnapshotRecursive(childID, profilingSnapshots)

--- a/src/devtools/views/Profiler/Interactions.js
+++ b/src/devtools/views/Profiler/Interactions.js
@@ -51,7 +51,7 @@ function Interactions({ height, width }: {| height: number, width: number |}) {
   } = useContext(ProfilerContext);
   const { profilingCache } = useContext(StoreContext);
 
-  const interactions = profilingCache.Interactions.read({
+  const { interactions } = profilingCache.Interactions.read({
     rendererID: ((rendererID: any): number),
     rootID: ((rootID: any): number),
   });

--- a/src/devtools/views/Profiler/ProfilingImportExportButtons.js
+++ b/src/devtools/views/Profiler/ProfilingImportExportButtons.js
@@ -6,11 +6,12 @@ import { ModalDialogContext } from '../ModalDialog';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import { BridgeContext, StoreContext } from '../context';
-import { prepareProfilingExport, prepareProfilingImport } from './utils';
+import {
+  prepareExportedProfilingSummary,
+  prepareImportedProfilingData,
+} from './utils';
 
 import styles from './ProfilingImportExportButtons.css';
-
-import type { ImportedProfilingData } from './types';
 
 export default function ProfilingImportExportButtons() {
   const bridge = useContext(BridgeContext);
@@ -28,15 +29,13 @@ export default function ProfilingImportExportButtons() {
       return;
     }
 
-    bridge.send(
-      'exportProfilingSummary',
-      prepareProfilingExport(
-        store.profilingOperations,
-        store.profilingSnapshots,
-        rootID,
-        rendererID
-      )
+    const exportedProfilingSummary = prepareExportedProfilingSummary(
+      store.profilingOperations,
+      store.profilingSnapshots,
+      rootID,
+      rendererID
     );
+    bridge.send('exportProfilingSummary', exportedProfilingSummary);
   }, [
     bridge,
     rendererID,
@@ -58,9 +57,7 @@ export default function ProfilingImportExportButtons() {
       fileReader.addEventListener('load', () => {
         try {
           const raw = ((fileReader.result: any): string);
-          const data = prepareProfilingImport(raw);
-
-          store.importedProfilingData = ((data: any): ImportedProfilingData);
+          store.importedProfilingData = prepareImportedProfilingData(raw);
         } catch (error) {
           modalDialogDispatch({
             type: 'SHOW',
@@ -76,6 +73,7 @@ export default function ProfilingImportExportButtons() {
           });
         }
       });
+      // TODO (profiling) Handle fileReader errors.
       fileReader.readAsText(input.files[0]);
     }
   }, [modalDialogDispatch, store]);

--- a/src/devtools/views/Profiler/SidebarInteractions.js
+++ b/src/devtools/views/Profiler/SidebarInteractions.js
@@ -25,7 +25,7 @@ export default function SidebarInteractions(_: Props) {
     return <div className={styles.NothingSelected}>Nothing selected</div>;
   }
 
-  const interactions = profilingCache.Interactions.read({
+  const { interactions } = profilingCache.Interactions.read({
     rendererID: ((rendererID: any): number),
     rootID: ((rootID: any): number),
   });

--- a/src/devtools/views/Profiler/types.js
+++ b/src/devtools/views/Profiler/types.js
@@ -1,6 +1,11 @@
 // @flow
 
 import type { ElementType } from 'src/types';
+import type {
+  CommitDetailsBackend,
+  InteractionsBackend,
+  ProfilingSummaryBackend,
+} from 'src/backend/types';
 
 export type CommitTreeNodeFrontend = {|
   id: number,
@@ -28,14 +33,17 @@ export type InteractionWithCommitsFrontend = {|
   commits: Array<number>,
 |};
 
-export type InteractionsFrontend = Array<InteractionWithCommitsFrontend>;
+export type InteractionsFrontend = {|
+  interactions: Array<InteractionWithCommitsFrontend>,
+  rootID: number,
+|};
 
 export type CommitDetailsFrontend = {|
-  rootID: number,
-  commitIndex: number,
   actualDurations: Map<number, number>,
-  selfDurations: Map<number, number>,
+  commitIndex: number,
   interactions: Array<InteractionFrontend>,
+  rootID: number,
+  selfDurations: Map<number, number>,
 |};
 
 export type FiberCommitsFrontend = {|
@@ -68,10 +76,34 @@ export type ProfilingSnapshotNode = {|
 |};
 
 export type ImportedProfilingData = {|
-  version: number,
+  version: 3,
   profilingOperations: Map<number, Array<Uint32Array>>,
   profilingSnapshots: Map<number, Map<number, ProfilingSnapshotNode>>,
-  commitDetails: CommitDetailsFrontend,
+  commitDetails: Array<CommitDetailsFrontend>,
   interactions: InteractionsFrontend,
   profilingSummary: ProfilingSummaryFrontend,
+|};
+
+export type SerializableProfilingDataOperationsByRootID = Array<
+  [number, Array<Array<number>>]
+>;
+export type SerializableProfilingDataSnapshotsByRootID = Array<
+  [number, Array<[number, ProfilingSnapshotNode]>]
+>;
+
+export type ExportedProfilingSummaryFromFrontend = {|
+  version: 3,
+  profilingOperationsByRootID: SerializableProfilingDataOperationsByRootID,
+  profilingSnapshotsByRootID: SerializableProfilingDataSnapshotsByRootID,
+  rendererID: number,
+  rootID: number,
+|};
+
+export type ExportedProfilingData = {|
+  version: 3,
+  profilingOperationsByRootID: SerializableProfilingDataOperationsByRootID,
+  profilingSnapshotsByRootID: SerializableProfilingDataSnapshotsByRootID,
+  commitDetails: Array<CommitDetailsBackend>,
+  interactions: InteractionsBackend,
+  profilingSummary: ProfilingSummaryBackend,
 |};


### PR DESCRIPTION
Cleanup profile export/import data types, add export/import test

Strengthened the I/O-boundary type conversion logic.

Fixed type inconsistencies uncovered by removing `any` and
by making explicit type annotations and transformations.

In particular, these were likely malformed when restored from a file:
- `commitDetails`
- `interactions`
- `initialTreeBaseDurations`

The mismatches were Map vs interleaved Array.