### PR TITLE
Replaced adm-zip with node-archiver

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/preset-react": "^7.0.0",
     "@reach/menu-button": "^0.1.17",
     "@reach/tooltip": "^0.2.0",
-    "adm-zip": "^0.4.7",
+    "archiver": "^3.0.0",
     "babel-core": "^7.0.0-bridge",
     "babel-eslint": "^9.0.0",
     "babel-jest": "^24.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,7 +1474,7 @@ addons-linter@1.6.1:
   optionalDependencies:
     fsevents "2.0.1"
 
-adm-zip@^0.4.7, adm-zip@~0.4.x:
+adm-zip@~0.4.x:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.13.tgz#597e2f8cc3672151e1307d3e95cddbc75672314a"
   integrity sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==


### PR DESCRIPTION
Hello,
Firefox zip from demo website can't be imported and is corrupted (Same behavior than #34). I tried building the extension from scratch and got the same corrupted archive.
After some digging, it looks like the latest version of adm-zip introduced this issue for some users. 

Despite that switching to a prior version fixes the problem, this PR replaces adm-zip with ```node-archiver``` which is already in the dependency tree of the project.