### PR TITLE
[Flare] Ensure DOM inspection is Flare compatible

### DIFF
--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -472,7 +472,9 @@ export default class Agent extends EventEmitter {
     window.addEventListener('click', this._onClick, true);
     window.addEventListener('mousedown', this._onMouseDown, true);
     window.addEventListener('mouseup', this._onMouseUp, true);
-    window.addEventListener('mouseover', this._onMouseOver, true);
+    window.addEventListener('pointerover', this._onPointerOver, true);
+    window.addEventListener('pointerdown', this._onPointerDown, true);
+    window.addEventListener('pointerup', this._onPointerUp, true);
   };
 
   startProfiling = () => {
@@ -492,7 +494,9 @@ export default class Agent extends EventEmitter {
     window.removeEventListener('click', this._onClick, true);
     window.removeEventListener('mousedown', this._onMouseDown, true);
     window.removeEventListener('mouseup', this._onMouseUp, true);
-    window.removeEventListener('mouseover', this._onMouseOver, true);
+    window.removeEventListener('pointerover', this._onPointerOver, true);
+    window.removeEventListener('pointerdown', this._onPointerDown, true);
+    window.removeEventListener('pointerup', this._onPointerUp, true);
   };
 
   stopProfiling = () => {
@@ -589,6 +593,11 @@ export default class Agent extends EventEmitter {
   _onMouseDown = (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
+  };
+
+  _onPointerDown = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
 
     this._selectFiberForNode(((event.target: any): HTMLElement));
   };
@@ -601,7 +610,12 @@ export default class Agent extends EventEmitter {
     event.stopPropagation();
   };
 
-  _onMouseOver = (event: MouseEvent) => {
+  _onPointerUp = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  _onPointerOver = (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
 


### PR DESCRIPTION
This should address the issues in https://github.com/bvaughn/react-devtools-experimental/issues/282. I haven't had the chance to check manually as it's late here; I can check this next week once I'm back from PTO :)

The general solution should work because Flare uses Pointer Events and Dev Tools only uses mouse events. Pointer events fire _before_ mouse events, and also Flare fires many events to do with pressing in both the `pointerdown` and `pointerup` events – so if we `stopPropagation()` in these events, it should block them from propagating to Flare's event listeners on the `document` (dev tools uses the `window`).

I moved the logic for dev tools into the relevant pointer events too – which should be fine as the only major browser that doesn't yet support Pointer Events in Safari and I don't believe we have any extension for dev tools for that platform. I changed the mouse events to only block events (`stopPropagation`, `preventDefault`) from firing on the heritage React event system.