### PR TITLE
Remove unsupported field from Firefox build

### DIFF
--- a/shells/browser/shared/build.js
+++ b/shells/browser/shared/build.js
@@ -63,7 +63,9 @@ const build = async (tempPath, manifestPath) => {
 
   const manifest = JSON.parse(readFileSync(copiedManifestPath).toString());
   manifest.description += `\n\nCreated from revision ${commit} (${new Date().toLocaleDateString()})`;
-  manifest.version_name = `${commit} (${new Date().toLocaleDateString()})`;
+  if (tempPath.includes('chrome')) {
+    manifest.version_name = `${commit} (${new Date().toLocaleDateString()})`;
+  }
   writeFileSync(copiedManifestPath, JSON.stringify(manifest, null, 2));
 
   // Pack the extension


### PR DESCRIPTION
Hello,
Adding the extension in firefox shows a warning message related to WebExtension manifest file

![Capture d’écran de 2019-06-04 22-32-19](https://user-images.githubusercontent.com/1423022/58915922-14d65100-871a-11e9-82c9-3aac5a1dd46c.png)

Looks like Firefox WebExtension API [does not support ```version_name``` property yet](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name)

This PR removes version_name from Firefox manifest file
