### PR TITLE
Add profiling option to track why a component rendered

### DIFF
--- a/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -94,21 +94,24 @@ exports[`ProfilingCache should collect data for each commit: CommitDetails commi
 Object {
   "changeDescriptions": Map {
     3 => Object {
+      "context": null,
       "didHooksChange": false,
       "props": Array [],
-      "state": Array [],
+      "state": null,
     },
     4 => Object {
+      "context": null,
       "didHooksChange": false,
       "props": Array [],
-      "state": Array [],
+      "state": null,
     },
     2 => Object {
+      "context": null,
       "didHooksChange": false,
       "props": Array [
         "count",
       ],
-      "state": Array [],
+      "state": null,
     },
   },
   "duration": 13,
@@ -137,16 +140,18 @@ exports[`ProfilingCache should collect data for each commit: CommitDetails commi
 Object {
   "changeDescriptions": Map {
     3 => Object {
+      "context": null,
       "didHooksChange": false,
       "props": Array [],
-      "state": Array [],
+      "state": null,
     },
     2 => Object {
+      "context": null,
       "didHooksChange": false,
       "props": Array [
         "count",
       ],
-      "state": Array [],
+      "state": null,
     },
   },
   "duration": 10,
@@ -171,11 +176,12 @@ exports[`ProfilingCache should collect data for each commit: CommitDetails commi
 Object {
   "changeDescriptions": Map {
     2 => Object {
+      "context": null,
       "didHooksChange": false,
       "props": Array [
         "count",
       ],
-      "state": Array [],
+      "state": null,
     },
   },
   "duration": 10,
@@ -256,27 +262,30 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               4,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -335,19 +344,21 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -390,11 +401,12 @@ Object {
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -662,19 +674,21 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -725,27 +739,30 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               5,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -949,21 +966,24 @@ Object {
     Object {
       "changeDescriptions": Map {
         3 => Object {
+          "context": null,
           "didHooksChange": false,
           "props": Array [],
-          "state": Array [],
+          "state": null,
         },
         4 => Object {
+          "context": null,
           "didHooksChange": false,
           "props": Array [],
-          "state": Array [],
+          "state": null,
         },
         2 => Object {
+          "context": null,
           "didHooksChange": false,
           "props": Array [
             "count",
           ],
-          "state": Array [],
+          "state": null,
         },
       },
       "duration": 13,
@@ -989,16 +1009,18 @@ Object {
     Object {
       "changeDescriptions": Map {
         3 => Object {
+          "context": null,
           "didHooksChange": false,
           "props": Array [],
-          "state": Array [],
+          "state": null,
         },
         2 => Object {
+          "context": null,
           "didHooksChange": false,
           "props": Array [
             "count",
           ],
-          "state": Array [],
+          "state": null,
         },
       },
       "duration": 10,
@@ -1020,11 +1042,12 @@ Object {
     Object {
       "changeDescriptions": Map {
         2 => Object {
+          "context": null,
           "didHooksChange": false,
           "props": Array [
             "count",
           ],
-          "state": Array [],
+          "state": null,
         },
       },
       "duration": 10,
@@ -1343,27 +1366,30 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               4,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -1422,19 +1448,21 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -1477,11 +1505,12 @@ Object {
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],
@@ -1878,6 +1907,488 @@ Object {
 }
 `;
 
+exports[`ProfilingCache should record when props/state/hooks change: CommitDetails commitIndex: 0 1`] = `
+Object {
+  "changeDescriptions": Map {},
+  "duration": 0,
+  "fiberActualDurations": Map {
+    1 => 0,
+    2 => 0,
+    3 => 0,
+    4 => 0,
+    5 => 0,
+    6 => 0,
+    7 => 0,
+  },
+  "fiberSelfDurations": Map {
+    1 => 0,
+    2 => 0,
+    3 => 0,
+    4 => 0,
+    5 => 0,
+    6 => 0,
+    7 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record when props/state/hooks change: CommitDetails commitIndex: 1 1`] = `
+Object {
+  "changeDescriptions": Map {
+    5 => Object {
+      "context": null,
+      "didHooksChange": true,
+      "props": Array [
+        "count",
+      ],
+      "state": null,
+    },
+    4 => Object {
+      "context": true,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    7 => Object {
+      "context": null,
+      "didHooksChange": true,
+      "props": Array [
+        "count",
+      ],
+      "state": null,
+    },
+    6 => Object {
+      "context": Array [
+        "count",
+      ],
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": Array [
+        "count",
+      ],
+    },
+  },
+  "duration": 0,
+  "fiberActualDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+  },
+  "fiberSelfDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record when props/state/hooks change: imported data 1`] = `
+Object {
+  "dataForRoots": Array [
+    Object {
+      "commitData": Array [
+        Object {
+          "changeDescriptions": Array [],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              1,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              1,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+        Object {
+          "changeDescriptions": Array [
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": true,
+                "props": Array [
+                  "count",
+                ],
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": true,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              7,
+              Object {
+                "context": null,
+                "didHooksChange": true,
+                "props": Array [
+                  "count",
+                ],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": Array [
+                  "count",
+                ],
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [
+                  "count",
+                ],
+              },
+            ],
+          ],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+      ],
+      "displayName": "LegacyContextProvider",
+      "initialTreeBaseDurations": Array [],
+      "interactionCommits": Array [],
+      "interactions": Array [],
+      "operations": Array [
+        Array [
+          1,
+          1,
+          110,
+          21,
+          76,
+          101,
+          103,
+          97,
+          99,
+          121,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          80,
+          114,
+          111,
+          118,
+          105,
+          100,
+          101,
+          114,
+          16,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          46,
+          80,
+          114,
+          111,
+          118,
+          105,
+          100,
+          101,
+          114,
+          21,
+          77,
+          111,
+          100,
+          101,
+          114,
+          110,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          67,
+          111,
+          110,
+          115,
+          117,
+          109,
+          101,
+          114,
+          26,
+          70,
+          117,
+          110,
+          99,
+          116,
+          105,
+          111,
+          110,
+          67,
+          111,
+          109,
+          112,
+          111,
+          110,
+          101,
+          110,
+          116,
+          87,
+          105,
+          116,
+          104,
+          72,
+          111,
+          111,
+          107,
+          115,
+          21,
+          76,
+          101,
+          103,
+          97,
+          99,
+          121,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          67,
+          111,
+          110,
+          115,
+          117,
+          109,
+          101,
+          114,
+          1,
+          1,
+          11,
+          1,
+          1,
+          1,
+          2,
+          1,
+          1,
+          0,
+          1,
+          0,
+          4,
+          2,
+          0,
+          1,
+          3,
+          2,
+          2,
+          2,
+          2,
+          0,
+          4,
+          3,
+          0,
+          1,
+          4,
+          1,
+          3,
+          2,
+          3,
+          0,
+          4,
+          4,
+          0,
+          1,
+          5,
+          5,
+          4,
+          4,
+          4,
+          0,
+          4,
+          5,
+          0,
+          1,
+          6,
+          1,
+          3,
+          2,
+          5,
+          0,
+          4,
+          6,
+          0,
+          1,
+          7,
+          5,
+          6,
+          6,
+          4,
+          0,
+          4,
+          7,
+          0,
+        ],
+        Array [
+          1,
+          1,
+          0,
+        ],
+      ],
+      "rootID": 1,
+      "snapshots": Array [],
+    },
+  ],
+  "version": 4,
+}
+`;
+
 exports[`ProfilingCache should report every traced interaction: Interactions 1`] = `
 Array [
   Object {
@@ -1951,19 +2462,21 @@ Object {
             Array [
               3,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [],
-                "state": Array [],
+                "state": null,
               },
             ],
             Array [
               2,
               Object {
+                "context": null,
                 "didHooksChange": false,
                 "props": Array [
                   "count",
                 ],
-                "state": Array [],
+                "state": null,
               },
             ],
           ],

--- a/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -2,7 +2,29 @@
 
 exports[`ProfilingCache should calculate a self duration based on actual children (not filtered children): CommitDetails with filtered self durations 1`] = `
 Object {
-  "changeDescriptions": Map {},
+  "changeDescriptions": Map {
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    3 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+  },
   "duration": 16,
   "fiberActualDurations": Map {
     1 => 16,
@@ -25,7 +47,22 @@ Object {
 
 exports[`ProfilingCache should calculate self duration correctly for suspended views: CommitDetails with filtered self durations 1`] = `
 Object {
-  "changeDescriptions": Map {},
+  "changeDescriptions": Map {
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    4 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+  },
   "duration": 15,
   "fiberActualDurations": Map {
     1 => 15,
@@ -48,7 +85,15 @@ Object {
 
 exports[`ProfilingCache should calculate self duration correctly for suspended views: CommitDetails with filtered self durations 2`] = `
 Object {
-  "changeDescriptions": Map {},
+  "changeDescriptions": Map {
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+  },
   "duration": 3,
   "fiberActualDurations": Map {
     5 => 3,
@@ -67,7 +112,36 @@ Object {
 
 exports[`ProfilingCache should collect data for each commit: CommitDetails commitIndex: 0 1`] = `
 Object {
-  "changeDescriptions": Map {},
+  "changeDescriptions": Map {
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    3 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    4 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+  },
   "duration": 12,
   "fiberActualDurations": Map {
     1 => 12,
@@ -96,18 +170,28 @@ Object {
     3 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     4 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
+      "state": null,
+    },
+    6 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
       "state": null,
     },
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [
         "count",
       ],
@@ -142,12 +226,14 @@ Object {
     3 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [
         "count",
       ],
@@ -178,6 +264,7 @@ Object {
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [
         "count",
       ],
@@ -206,7 +293,48 @@ Object {
     Object {
       "commitData": Array [
         Object {
-          "changeDescriptions": Array [],
+          "changeDescriptions": Array [
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              3,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+          ],
           "duration": 12,
           "fiberActualDurations": Array [
             Array [
@@ -264,6 +392,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -273,7 +402,18 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
                 "state": null,
               },
             ],
@@ -282,6 +422,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -346,6 +487,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -355,6 +497,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -403,6 +546,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -626,7 +770,38 @@ Object {
     Object {
       "commitData": Array [
         Object {
-          "changeDescriptions": Array [],
+          "changeDescriptions": Array [
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              3,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+          ],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -676,7 +851,18 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
                 "state": null,
               },
             ],
@@ -685,6 +871,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -741,6 +928,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -750,7 +938,18 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
                 "state": null,
               },
             ],
@@ -759,6 +958,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -968,18 +1168,28 @@ Object {
         3 => Object {
           "context": null,
           "didHooksChange": false,
+          "isFirstMount": false,
           "props": Array [],
           "state": null,
         },
         4 => Object {
           "context": null,
           "didHooksChange": false,
+          "isFirstMount": false,
           "props": Array [],
+          "state": null,
+        },
+        10 => Object {
+          "context": null,
+          "didHooksChange": false,
+          "isFirstMount": true,
+          "props": null,
           "state": null,
         },
         2 => Object {
           "context": null,
           "didHooksChange": false,
+          "isFirstMount": false,
           "props": Array [
             "count",
           ],
@@ -1011,12 +1221,14 @@ Object {
         3 => Object {
           "context": null,
           "didHooksChange": false,
+          "isFirstMount": false,
           "props": Array [],
           "state": null,
         },
         2 => Object {
           "context": null,
           "didHooksChange": false,
+          "isFirstMount": false,
           "props": Array [
             "count",
           ],
@@ -1044,6 +1256,7 @@ Object {
         2 => Object {
           "context": null,
           "didHooksChange": false,
+          "isFirstMount": false,
           "props": Array [
             "count",
           ],
@@ -1192,7 +1405,29 @@ exports[`ProfilingCache should collect data for each root (including ones added 
 Object {
   "commitData": Array [
     Object {
-      "changeDescriptions": Map {},
+      "changeDescriptions": Map {
+        12 => Object {
+          "context": null,
+          "didHooksChange": false,
+          "isFirstMount": true,
+          "props": null,
+          "state": null,
+        },
+        13 => Object {
+          "context": null,
+          "didHooksChange": false,
+          "isFirstMount": true,
+          "props": null,
+          "state": null,
+        },
+        14 => Object {
+          "context": null,
+          "didHooksChange": false,
+          "isFirstMount": true,
+          "props": null,
+          "state": null,
+        },
+      },
       "duration": 11,
       "fiberActualDurations": Map {
         11 => 11,
@@ -1368,6 +1603,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -1377,7 +1613,18 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              10,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
                 "state": null,
               },
             ],
@@ -1386,6 +1633,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -1450,6 +1698,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -1459,6 +1708,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -1507,6 +1757,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -1695,7 +1946,38 @@ Object {
     Object {
       "commitData": Array [
         Object {
-          "changeDescriptions": Array [],
+          "changeDescriptions": Array [
+            Array [
+              12,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              13,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              14,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+          ],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -1909,7 +2191,43 @@ Object {
 
 exports[`ProfilingCache should record changed props/state/context/hooks: CommitDetails commitIndex: 0 1`] = `
 Object {
-  "changeDescriptions": Map {},
+  "changeDescriptions": Map {
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    4 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    6 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+    7 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "isFirstMount": true,
+      "props": null,
+      "state": null,
+    },
+  },
   "duration": 0,
   "fiberActualDurations": Map {
     1 => 0,
@@ -1942,6 +2260,7 @@ Object {
     5 => Object {
       "context": null,
       "didHooksChange": true,
+      "isFirstMount": false,
       "props": Array [
         "count",
       ],
@@ -1950,12 +2269,14 @@ Object {
     4 => Object {
       "context": true,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     7 => Object {
       "context": null,
       "didHooksChange": true,
+      "isFirstMount": false,
       "props": Array [
         "count",
       ],
@@ -1966,12 +2287,14 @@ Object {
         "count",
       ],
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": Array [
         "count",
@@ -2008,30 +2331,35 @@ Object {
     5 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     4 => Object {
       "context": false,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     7 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     6 => Object {
       "context": Array [],
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [
         "foo",
       ],
@@ -2070,30 +2398,35 @@ Object {
     5 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     4 => Object {
       "context": false,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     7 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     6 => Object {
       "context": Array [],
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [
         "foo",
         "bar",
@@ -2133,30 +2466,35 @@ Object {
     5 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     4 => Object {
       "context": false,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     7 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     6 => Object {
       "context": Array [],
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [],
       "state": null,
     },
     2 => Object {
       "context": null,
       "didHooksChange": false,
+      "isFirstMount": false,
       "props": Array [
         "bar",
       ],
@@ -2195,7 +2533,58 @@ Object {
     Object {
       "commitData": Array [
         Object {
-          "changeDescriptions": Array [],
+          "changeDescriptions": Array [
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              7,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+          ],
           "duration": 0,
           "fiberActualDurations": Array [
             Array [
@@ -2269,6 +2658,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": true,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -2280,6 +2670,7 @@ Object {
               Object {
                 "context": true,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2289,6 +2680,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": true,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],
@@ -2302,6 +2694,7 @@ Object {
                   "count",
                 ],
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2311,6 +2704,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": Array [
                   "count",
@@ -2383,6 +2777,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2392,6 +2787,7 @@ Object {
               Object {
                 "context": false,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2401,6 +2797,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2410,6 +2807,7 @@ Object {
               Object {
                 "context": Array [],
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2419,6 +2817,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "foo",
                 ],
@@ -2499,6 +2898,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2508,6 +2908,7 @@ Object {
               Object {
                 "context": false,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2517,6 +2918,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2526,6 +2928,7 @@ Object {
               Object {
                 "context": Array [],
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2535,6 +2938,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "foo",
                   "bar",
@@ -2616,6 +3020,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2625,6 +3030,7 @@ Object {
               Object {
                 "context": false,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2634,6 +3040,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2643,6 +3050,7 @@ Object {
               Object {
                 "context": Array [],
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
                 "state": null,
               },
@@ -2652,6 +3060,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "bar",
                 ],
@@ -2924,488 +3333,6 @@ Object {
         Array [
           1,
           1,
-          0,
-        ],
-        Array [
-          1,
-          1,
-          0,
-        ],
-      ],
-      "rootID": 1,
-      "snapshots": Array [],
-    },
-  ],
-  "version": 4,
-}
-`;
-
-exports[`ProfilingCache should record when props/state/hooks change: CommitDetails commitIndex: 0 1`] = `
-Object {
-  "changeDescriptions": Map {},
-  "duration": 0,
-  "fiberActualDurations": Map {
-    1 => 0,
-    2 => 0,
-    3 => 0,
-    4 => 0,
-    5 => 0,
-    6 => 0,
-    7 => 0,
-  },
-  "fiberSelfDurations": Map {
-    1 => 0,
-    2 => 0,
-    3 => 0,
-    4 => 0,
-    5 => 0,
-    6 => 0,
-    7 => 0,
-  },
-  "interactionIDs": Array [],
-  "priorityLevel": "Immediate",
-  "screenshot": null,
-  "timestamp": 0,
-}
-`;
-
-exports[`ProfilingCache should record when props/state/hooks change: CommitDetails commitIndex: 1 1`] = `
-Object {
-  "changeDescriptions": Map {
-    5 => Object {
-      "context": null,
-      "didHooksChange": true,
-      "props": Array [
-        "count",
-      ],
-      "state": null,
-    },
-    4 => Object {
-      "context": true,
-      "didHooksChange": false,
-      "props": Array [],
-      "state": null,
-    },
-    7 => Object {
-      "context": null,
-      "didHooksChange": true,
-      "props": Array [
-        "count",
-      ],
-      "state": null,
-    },
-    6 => Object {
-      "context": Array [
-        "count",
-      ],
-      "didHooksChange": false,
-      "props": Array [],
-      "state": null,
-    },
-    2 => Object {
-      "context": null,
-      "didHooksChange": false,
-      "props": Array [],
-      "state": Array [
-        "count",
-      ],
-    },
-  },
-  "duration": 0,
-  "fiberActualDurations": Map {
-    5 => 0,
-    4 => 0,
-    7 => 0,
-    6 => 0,
-    3 => 0,
-    2 => 0,
-  },
-  "fiberSelfDurations": Map {
-    5 => 0,
-    4 => 0,
-    7 => 0,
-    6 => 0,
-    3 => 0,
-    2 => 0,
-  },
-  "interactionIDs": Array [],
-  "priorityLevel": "Immediate",
-  "screenshot": null,
-  "timestamp": 0,
-}
-`;
-
-exports[`ProfilingCache should record when props/state/hooks change: imported data 1`] = `
-Object {
-  "dataForRoots": Array [
-    Object {
-      "commitData": Array [
-        Object {
-          "changeDescriptions": Array [],
-          "duration": 0,
-          "fiberActualDurations": Array [
-            Array [
-              1,
-              0,
-            ],
-            Array [
-              2,
-              0,
-            ],
-            Array [
-              3,
-              0,
-            ],
-            Array [
-              4,
-              0,
-            ],
-            Array [
-              5,
-              0,
-            ],
-            Array [
-              6,
-              0,
-            ],
-            Array [
-              7,
-              0,
-            ],
-          ],
-          "fiberSelfDurations": Array [
-            Array [
-              1,
-              0,
-            ],
-            Array [
-              2,
-              0,
-            ],
-            Array [
-              3,
-              0,
-            ],
-            Array [
-              4,
-              0,
-            ],
-            Array [
-              5,
-              0,
-            ],
-            Array [
-              6,
-              0,
-            ],
-            Array [
-              7,
-              0,
-            ],
-          ],
-          "interactionIDs": Array [],
-          "priorityLevel": "Immediate",
-          "screenshot": null,
-          "timestamp": 0,
-        },
-        Object {
-          "changeDescriptions": Array [
-            Array [
-              5,
-              Object {
-                "context": null,
-                "didHooksChange": true,
-                "props": Array [
-                  "count",
-                ],
-                "state": null,
-              },
-            ],
-            Array [
-              4,
-              Object {
-                "context": true,
-                "didHooksChange": false,
-                "props": Array [],
-                "state": null,
-              },
-            ],
-            Array [
-              7,
-              Object {
-                "context": null,
-                "didHooksChange": true,
-                "props": Array [
-                  "count",
-                ],
-                "state": null,
-              },
-            ],
-            Array [
-              6,
-              Object {
-                "context": Array [
-                  "count",
-                ],
-                "didHooksChange": false,
-                "props": Array [],
-                "state": null,
-              },
-            ],
-            Array [
-              2,
-              Object {
-                "context": null,
-                "didHooksChange": false,
-                "props": Array [],
-                "state": Array [
-                  "count",
-                ],
-              },
-            ],
-          ],
-          "duration": 0,
-          "fiberActualDurations": Array [
-            Array [
-              5,
-              0,
-            ],
-            Array [
-              4,
-              0,
-            ],
-            Array [
-              7,
-              0,
-            ],
-            Array [
-              6,
-              0,
-            ],
-            Array [
-              3,
-              0,
-            ],
-            Array [
-              2,
-              0,
-            ],
-          ],
-          "fiberSelfDurations": Array [
-            Array [
-              5,
-              0,
-            ],
-            Array [
-              4,
-              0,
-            ],
-            Array [
-              7,
-              0,
-            ],
-            Array [
-              6,
-              0,
-            ],
-            Array [
-              3,
-              0,
-            ],
-            Array [
-              2,
-              0,
-            ],
-          ],
-          "interactionIDs": Array [],
-          "priorityLevel": "Immediate",
-          "screenshot": null,
-          "timestamp": 0,
-        },
-      ],
-      "displayName": "LegacyContextProvider",
-      "initialTreeBaseDurations": Array [],
-      "interactionCommits": Array [],
-      "interactions": Array [],
-      "operations": Array [
-        Array [
-          1,
-          1,
-          110,
-          21,
-          76,
-          101,
-          103,
-          97,
-          99,
-          121,
-          67,
-          111,
-          110,
-          116,
-          101,
-          120,
-          116,
-          80,
-          114,
-          111,
-          118,
-          105,
-          100,
-          101,
-          114,
-          16,
-          67,
-          111,
-          110,
-          116,
-          101,
-          120,
-          116,
-          46,
-          80,
-          114,
-          111,
-          118,
-          105,
-          100,
-          101,
-          114,
-          21,
-          77,
-          111,
-          100,
-          101,
-          114,
-          110,
-          67,
-          111,
-          110,
-          116,
-          101,
-          120,
-          116,
-          67,
-          111,
-          110,
-          115,
-          117,
-          109,
-          101,
-          114,
-          26,
-          70,
-          117,
-          110,
-          99,
-          116,
-          105,
-          111,
-          110,
-          67,
-          111,
-          109,
-          112,
-          111,
-          110,
-          101,
-          110,
-          116,
-          87,
-          105,
-          116,
-          104,
-          72,
-          111,
-          111,
-          107,
-          115,
-          21,
-          76,
-          101,
-          103,
-          97,
-          99,
-          121,
-          67,
-          111,
-          110,
-          116,
-          101,
-          120,
-          116,
-          67,
-          111,
-          110,
-          115,
-          117,
-          109,
-          101,
-          114,
-          1,
-          1,
-          11,
-          1,
-          1,
-          1,
-          2,
-          1,
-          1,
-          0,
-          1,
-          0,
-          4,
-          2,
-          0,
-          1,
-          3,
-          2,
-          2,
-          2,
-          2,
-          0,
-          4,
-          3,
-          0,
-          1,
-          4,
-          1,
-          3,
-          2,
-          3,
-          0,
-          4,
-          4,
-          0,
-          1,
-          5,
-          5,
-          4,
-          4,
-          4,
-          0,
-          4,
-          5,
-          0,
-          1,
-          6,
-          1,
-          3,
-          2,
-          5,
-          0,
-          4,
-          6,
-          0,
-          1,
-          7,
-          5,
-          6,
-          6,
-          4,
-          0,
-          4,
-          7,
           0,
         ],
         Array [
@@ -3445,7 +3372,38 @@ Object {
     Object {
       "commitData": Array [
         Object {
-          "changeDescriptions": Array [],
+          "changeDescriptions": Array [
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              3,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
+                "state": null,
+              },
+            ],
+          ],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -3497,7 +3455,18 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "isFirstMount": true,
+                "props": null,
                 "state": null,
               },
             ],
@@ -3506,6 +3475,7 @@ Object {
               Object {
                 "context": null,
                 "didHooksChange": false,
+                "isFirstMount": false,
                 "props": Array [
                   "count",
                 ],

--- a/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`ProfilingCache should calculate a self duration based on actual children (not filtered children): CommitDetails with filtered self durations 1`] = `
 Object {
+  "changeDescriptions": Map {},
   "duration": 16,
   "fiberActualDurations": Map {
     1 => 16,
@@ -24,6 +25,7 @@ Object {
 
 exports[`ProfilingCache should calculate self duration correctly for suspended views: CommitDetails with filtered self durations 1`] = `
 Object {
+  "changeDescriptions": Map {},
   "duration": 15,
   "fiberActualDurations": Map {
     1 => 15,
@@ -46,6 +48,7 @@ Object {
 
 exports[`ProfilingCache should calculate self duration correctly for suspended views: CommitDetails with filtered self durations 2`] = `
 Object {
+  "changeDescriptions": Map {},
   "duration": 3,
   "fiberActualDurations": Map {
     5 => 3,
@@ -64,6 +67,7 @@ Object {
 
 exports[`ProfilingCache should collect data for each commit: CommitDetails commitIndex: 0 1`] = `
 Object {
+  "changeDescriptions": Map {},
   "duration": 12,
   "fiberActualDurations": Map {
     1 => 12,
@@ -88,6 +92,25 @@ Object {
 
 exports[`ProfilingCache should collect data for each commit: CommitDetails commitIndex: 1 1`] = `
 Object {
+  "changeDescriptions": Map {
+    3 => Object {
+      "didHooksChange": false,
+      "props": Array [],
+      "state": Array [],
+    },
+    4 => Object {
+      "didHooksChange": false,
+      "props": Array [],
+      "state": Array [],
+    },
+    2 => Object {
+      "didHooksChange": false,
+      "props": Array [
+        "count",
+      ],
+      "state": Array [],
+    },
+  },
   "duration": 13,
   "fiberActualDurations": Map {
     3 => 0,
@@ -112,6 +135,20 @@ Object {
 
 exports[`ProfilingCache should collect data for each commit: CommitDetails commitIndex: 2 1`] = `
 Object {
+  "changeDescriptions": Map {
+    3 => Object {
+      "didHooksChange": false,
+      "props": Array [],
+      "state": Array [],
+    },
+    2 => Object {
+      "didHooksChange": false,
+      "props": Array [
+        "count",
+      ],
+      "state": Array [],
+    },
+  },
   "duration": 10,
   "fiberActualDurations": Map {
     3 => 0,
@@ -132,6 +169,15 @@ Object {
 
 exports[`ProfilingCache should collect data for each commit: CommitDetails commitIndex: 3 1`] = `
 Object {
+  "changeDescriptions": Map {
+    2 => Object {
+      "didHooksChange": false,
+      "props": Array [
+        "count",
+      ],
+      "state": Array [],
+    },
+  },
   "duration": 10,
   "fiberActualDurations": Map {
     2 => 10,
@@ -154,6 +200,7 @@ Object {
     Object {
       "commitData": Array [
         Object {
+          "changeDescriptions": Array [],
           "duration": 12,
           "fiberActualDurations": Array [
             Array [
@@ -205,6 +252,34 @@ Object {
           "timestamp": 12,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 13,
           "fiberActualDurations": Array [
             Array [
@@ -256,6 +331,26 @@ Object {
           "timestamp": 25,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 10,
           "fiberActualDurations": Array [
             Array [
@@ -291,6 +386,18 @@ Object {
           "timestamp": 35,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 10,
           "fiberActualDurations": Array [
             Array [
@@ -507,6 +614,7 @@ Object {
     Object {
       "commitData": Array [
         Object {
+          "changeDescriptions": Array [],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -550,6 +658,26 @@ Object {
           "timestamp": 11,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -593,6 +721,34 @@ Object {
           "timestamp": 22,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              5,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 13,
           "fiberActualDurations": Array [
             Array [
@@ -791,6 +947,25 @@ exports[`ProfilingCache should collect data for each root (including ones added 
 Object {
   "commitData": Array [
     Object {
+      "changeDescriptions": Map {
+        3 => Object {
+          "didHooksChange": false,
+          "props": Array [],
+          "state": Array [],
+        },
+        4 => Object {
+          "didHooksChange": false,
+          "props": Array [],
+          "state": Array [],
+        },
+        2 => Object {
+          "didHooksChange": false,
+          "props": Array [
+            "count",
+          ],
+          "state": Array [],
+        },
+      },
       "duration": 13,
       "fiberActualDurations": Map {
         3 => 0,
@@ -812,6 +987,20 @@ Object {
       "timestamp": 13,
     },
     Object {
+      "changeDescriptions": Map {
+        3 => Object {
+          "didHooksChange": false,
+          "props": Array [],
+          "state": Array [],
+        },
+        2 => Object {
+          "didHooksChange": false,
+          "props": Array [
+            "count",
+          ],
+          "state": Array [],
+        },
+      },
       "duration": 10,
       "fiberActualDurations": Map {
         3 => 0,
@@ -829,6 +1018,15 @@ Object {
       "timestamp": 34,
     },
     Object {
+      "changeDescriptions": Map {
+        2 => Object {
+          "didHooksChange": false,
+          "props": Array [
+            "count",
+          ],
+          "state": Array [],
+        },
+      },
       "duration": 10,
       "fiberActualDurations": Map {
         2 => 10,
@@ -971,6 +1169,7 @@ exports[`ProfilingCache should collect data for each root (including ones added 
 Object {
   "commitData": Array [
     Object {
+      "changeDescriptions": Map {},
       "duration": 11,
       "fiberActualDurations": Map {
         11 => 11,
@@ -1063,6 +1262,7 @@ exports[`ProfilingCache should collect data for each root (including ones added 
 Object {
   "commitData": Array [
     Object {
+      "changeDescriptions": Map {},
       "duration": 0,
       "fiberActualDurations": Map {},
       "fiberSelfDurations": Map {},
@@ -1139,6 +1339,34 @@ Object {
     Object {
       "commitData": Array [
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 13,
           "fiberActualDurations": Array [
             Array [
@@ -1190,6 +1418,26 @@ Object {
           "timestamp": 13,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 10,
           "fiberActualDurations": Array [
             Array [
@@ -1225,6 +1473,18 @@ Object {
           "timestamp": 34,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 10,
           "fiberActualDurations": Array [
             Array [
@@ -1406,6 +1666,7 @@ Object {
     Object {
       "commitData": Array [
         Object {
+          "changeDescriptions": Array [],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -1519,6 +1780,7 @@ Object {
     Object {
       "commitData": Array [
         Object {
+          "changeDescriptions": Array [],
           "duration": 0,
           "fiberActualDurations": Array [],
           "fiberSelfDurations": Array [],
@@ -1639,6 +1901,7 @@ Object {
     Object {
       "commitData": Array [
         Object {
+          "changeDescriptions": Array [],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [
@@ -1684,6 +1947,26 @@ Object {
           "timestamp": 11,
         },
         Object {
+          "changeDescriptions": Array [
+            Array [
+              3,
+              Object {
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [],
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "didHooksChange": false,
+                "props": Array [
+                  "count",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
           "duration": 11,
           "fiberActualDurations": Array [
             Array [

--- a/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -1907,6 +1907,1039 @@ Object {
 }
 `;
 
+exports[`ProfilingCache should record changed props/state/context/hooks: CommitDetails commitIndex: 0 1`] = `
+Object {
+  "changeDescriptions": Map {},
+  "duration": 0,
+  "fiberActualDurations": Map {
+    1 => 0,
+    2 => 0,
+    3 => 0,
+    4 => 0,
+    5 => 0,
+    6 => 0,
+    7 => 0,
+  },
+  "fiberSelfDurations": Map {
+    1 => 0,
+    2 => 0,
+    3 => 0,
+    4 => 0,
+    5 => 0,
+    6 => 0,
+    7 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record changed props/state/context/hooks: CommitDetails commitIndex: 1 1`] = `
+Object {
+  "changeDescriptions": Map {
+    5 => Object {
+      "context": null,
+      "didHooksChange": true,
+      "props": Array [
+        "count",
+      ],
+      "state": null,
+    },
+    4 => Object {
+      "context": true,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    7 => Object {
+      "context": null,
+      "didHooksChange": true,
+      "props": Array [
+        "count",
+      ],
+      "state": null,
+    },
+    6 => Object {
+      "context": Array [
+        "count",
+      ],
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": Array [
+        "count",
+      ],
+    },
+  },
+  "duration": 0,
+  "fiberActualDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+  },
+  "fiberSelfDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record changed props/state/context/hooks: CommitDetails commitIndex: 2 1`] = `
+Object {
+  "changeDescriptions": Map {
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    4 => Object {
+      "context": false,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    7 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    6 => Object {
+      "context": Array [],
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [
+        "foo",
+      ],
+      "state": Array [],
+    },
+  },
+  "duration": 0,
+  "fiberActualDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "fiberSelfDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record changed props/state/context/hooks: CommitDetails commitIndex: 3 1`] = `
+Object {
+  "changeDescriptions": Map {
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    4 => Object {
+      "context": false,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    7 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    6 => Object {
+      "context": Array [],
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [
+        "foo",
+        "bar",
+      ],
+      "state": Array [],
+    },
+  },
+  "duration": 0,
+  "fiberActualDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "fiberSelfDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record changed props/state/context/hooks: CommitDetails commitIndex: 4 1`] = `
+Object {
+  "changeDescriptions": Map {
+    5 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    4 => Object {
+      "context": false,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    7 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    6 => Object {
+      "context": Array [],
+      "didHooksChange": false,
+      "props": Array [],
+      "state": null,
+    },
+    2 => Object {
+      "context": null,
+      "didHooksChange": false,
+      "props": Array [
+        "bar",
+      ],
+      "state": Array [],
+    },
+  },
+  "duration": 0,
+  "fiberActualDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "fiberSelfDurations": Map {
+    5 => 0,
+    4 => 0,
+    7 => 0,
+    6 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "interactionIDs": Array [],
+  "priorityLevel": "Immediate",
+  "screenshot": null,
+  "timestamp": 0,
+}
+`;
+
+exports[`ProfilingCache should record changed props/state/context/hooks: imported data 1`] = `
+Object {
+  "dataForRoots": Array [
+    Object {
+      "commitData": Array [
+        Object {
+          "changeDescriptions": Array [],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              1,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              1,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+        Object {
+          "changeDescriptions": Array [
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": true,
+                "props": Array [
+                  "count",
+                ],
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": true,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              7,
+              Object {
+                "context": null,
+                "didHooksChange": true,
+                "props": Array [
+                  "count",
+                ],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": Array [
+                  "count",
+                ],
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": Array [
+                  "count",
+                ],
+              },
+            ],
+          ],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+        Object {
+          "changeDescriptions": Array [
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": false,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              7,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": Array [],
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [
+                  "foo",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+        Object {
+          "changeDescriptions": Array [
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": false,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              7,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": Array [],
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [
+                  "foo",
+                  "bar",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+        Object {
+          "changeDescriptions": Array [
+            Array [
+              5,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              4,
+              Object {
+                "context": false,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              7,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              6,
+              Object {
+                "context": Array [],
+                "didHooksChange": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+            Array [
+              2,
+              Object {
+                "context": null,
+                "didHooksChange": false,
+                "props": Array [
+                  "bar",
+                ],
+                "state": Array [],
+              },
+            ],
+          ],
+          "duration": 0,
+          "fiberActualDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              5,
+              0,
+            ],
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              7,
+              0,
+            ],
+            Array [
+              6,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "screenshot": null,
+          "timestamp": 0,
+        },
+      ],
+      "displayName": "LegacyContextProvider",
+      "initialTreeBaseDurations": Array [],
+      "interactionCommits": Array [],
+      "interactions": Array [],
+      "operations": Array [
+        Array [
+          1,
+          1,
+          110,
+          21,
+          76,
+          101,
+          103,
+          97,
+          99,
+          121,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          80,
+          114,
+          111,
+          118,
+          105,
+          100,
+          101,
+          114,
+          16,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          46,
+          80,
+          114,
+          111,
+          118,
+          105,
+          100,
+          101,
+          114,
+          21,
+          77,
+          111,
+          100,
+          101,
+          114,
+          110,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          67,
+          111,
+          110,
+          115,
+          117,
+          109,
+          101,
+          114,
+          26,
+          70,
+          117,
+          110,
+          99,
+          116,
+          105,
+          111,
+          110,
+          67,
+          111,
+          109,
+          112,
+          111,
+          110,
+          101,
+          110,
+          116,
+          87,
+          105,
+          116,
+          104,
+          72,
+          111,
+          111,
+          107,
+          115,
+          21,
+          76,
+          101,
+          103,
+          97,
+          99,
+          121,
+          67,
+          111,
+          110,
+          116,
+          101,
+          120,
+          116,
+          67,
+          111,
+          110,
+          115,
+          117,
+          109,
+          101,
+          114,
+          1,
+          1,
+          11,
+          1,
+          1,
+          1,
+          2,
+          1,
+          1,
+          0,
+          1,
+          0,
+          4,
+          2,
+          0,
+          1,
+          3,
+          2,
+          2,
+          2,
+          2,
+          0,
+          4,
+          3,
+          0,
+          1,
+          4,
+          1,
+          3,
+          2,
+          3,
+          0,
+          4,
+          4,
+          0,
+          1,
+          5,
+          5,
+          4,
+          4,
+          4,
+          0,
+          4,
+          5,
+          0,
+          1,
+          6,
+          1,
+          3,
+          2,
+          5,
+          0,
+          4,
+          6,
+          0,
+          1,
+          7,
+          5,
+          6,
+          6,
+          4,
+          0,
+          4,
+          7,
+          0,
+        ],
+        Array [
+          1,
+          1,
+          0,
+        ],
+        Array [
+          1,
+          1,
+          0,
+        ],
+        Array [
+          1,
+          1,
+          0,
+        ],
+        Array [
+          1,
+          1,
+          0,
+        ],
+      ],
+      "rootID": 1,
+      "snapshots": Array [],
+    },
+  ],
+  "version": 4,
+}
+`;
+
 exports[`ProfilingCache should record when props/state/hooks change: CommitDetails commitIndex: 0 1`] = `
 Object {
   "changeDescriptions": Map {},

--- a/src/__tests__/profilerContext-test.js
+++ b/src/__tests__/profilerContext-test.js
@@ -29,6 +29,7 @@ describe('ProfilerContext', () => {
     bridge = global.bridge;
     store = global.store;
     store.collapseNodesByDefault = false;
+    store.recordChangeDescriptions = true;
 
     React = require('react');
     ReactDOM = require('react-dom');

--- a/src/__tests__/profilerStore-test.js
+++ b/src/__tests__/profilerStore-test.js
@@ -14,6 +14,7 @@ describe('ProfilerStore', () => {
 
     store = global.store;
     store.collapseNodesByDefault = false;
+    store.recordChangeDescriptions = true;
 
     React = require('react');
     ReactDOM = require('react-dom');

--- a/src/__tests__/profilingCache-test.js
+++ b/src/__tests__/profilingCache-test.js
@@ -190,7 +190,7 @@ describe('ProfilingCache', () => {
     }
   });
 
-  it('should record when props/state/hooks change', () => {
+  it('should record changed props/state/context/hooks', () => {
     let instance = null;
 
     const ModernContext = React.createContext(0);
@@ -246,6 +246,13 @@ describe('ProfilingCache', () => {
     utils.act(() => ReactDOM.render(<LegacyContextProvider />, container));
     expect(instance).not.toBeNull();
     utils.act(() => (instance: any).setState({ count: 1 }));
+    utils.act(() =>
+      ReactDOM.render(<LegacyContextProvider foo={123} />, container)
+    );
+    utils.act(() =>
+      ReactDOM.render(<LegacyContextProvider bar="abc" />, container)
+    );
+    utils.act(() => ReactDOM.render(<LegacyContextProvider />, container));
     utils.act(() => store.profilerStore.stopProfiling());
 
     const allCommitData = [];
@@ -265,7 +272,7 @@ describe('ProfilingCache', () => {
 
     const rootID = store.roots[0];
 
-    for (let commitIndex = 0; commitIndex < 2; commitIndex++) {
+    for (let commitIndex = 0; commitIndex < 5; commitIndex++) {
       utils.act(() => {
         TestRenderer.create(
           <Validator
@@ -277,11 +284,11 @@ describe('ProfilingCache', () => {
       });
     }
 
-    expect(allCommitData).toHaveLength(2);
+    expect(allCommitData).toHaveLength(5);
 
     utils.exportImportHelper(bridge, store);
 
-    for (let commitIndex = 0; commitIndex < 2; commitIndex++) {
+    for (let commitIndex = 0; commitIndex < 5; commitIndex++) {
       utils.act(() => {
         TestRenderer.create(
           <Validator

--- a/src/__tests__/profilingCache-test.js
+++ b/src/__tests__/profilingCache-test.js
@@ -21,6 +21,7 @@ describe('ProfilingCache', () => {
     bridge = global.bridge;
     store = global.store;
     store.collapseNodesByDefault = false;
+    store.recordChangeDescriptions = true;
 
     React = require('react');
     ReactDOM = require('react-dom');

--- a/src/__tests__/profilingCache-test.js
+++ b/src/__tests__/profilingCache-test.js
@@ -5,6 +5,7 @@ import type Bridge from 'src/bridge';
 import type Store from 'src/devtools/store';
 
 describe('ProfilingCache', () => {
+  let PropTypes;
   let React;
   let ReactDOM;
   let Scheduler;
@@ -23,6 +24,7 @@ describe('ProfilingCache', () => {
     store.collapseNodesByDefault = false;
     store.recordChangeDescriptions = true;
 
+    PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');
     Scheduler = require('scheduler');
@@ -176,6 +178,110 @@ describe('ProfilingCache', () => {
     utils.exportImportHelper(bridge, store);
 
     for (let commitIndex = 0; commitIndex < 4; commitIndex++) {
+      utils.act(() => {
+        TestRenderer.create(
+          <Validator
+            commitIndex={commitIndex}
+            previousCommitDetails={allCommitData[commitIndex]}
+            rootID={rootID}
+          />
+        );
+      });
+    }
+  });
+
+  it('should record when props/state/hooks change', () => {
+    let instance = null;
+
+    const ModernContext = React.createContext(0);
+
+    class LegacyContextProvider extends React.Component<
+      any,
+      {| count: number |}
+    > {
+      static childContextTypes = {
+        count: PropTypes.number,
+      };
+      state = { count: 0 };
+      getChildContext() {
+        return this.state;
+      }
+      render() {
+        instance = this;
+        return (
+          <ModernContext.Provider value={this.state.count}>
+            <React.Fragment>
+              <ModernContextConsumer />
+              <LegacyContextConsumer />
+            </React.Fragment>
+          </ModernContext.Provider>
+        );
+      }
+    }
+
+    const FunctionComponentWithHooks = ({ count }) => {
+      React.useMemo(() => count, [count]);
+      return null;
+    };
+
+    class ModernContextConsumer extends React.Component<any> {
+      static contextType = ModernContext;
+      render() {
+        return <FunctionComponentWithHooks count={this.context} />;
+      }
+    }
+
+    class LegacyContextConsumer extends React.Component<any> {
+      static contextTypes = {
+        count: PropTypes.number,
+      };
+      render() {
+        return <FunctionComponentWithHooks count={this.context.count} />;
+      }
+    }
+
+    const container = document.createElement('div');
+
+    utils.act(() => store.profilerStore.startProfiling());
+    utils.act(() => ReactDOM.render(<LegacyContextProvider />, container));
+    expect(instance).not.toBeNull();
+    utils.act(() => (instance: any).setState({ count: 1 }));
+    utils.act(() => store.profilerStore.stopProfiling());
+
+    const allCommitData = [];
+
+    function Validator({ commitIndex, previousCommitDetails, rootID }) {
+      const commitData = store.profilerStore.getCommitData(rootID, commitIndex);
+      if (previousCommitDetails != null) {
+        expect(commitData).toEqual(previousCommitDetails);
+      } else {
+        allCommitData.push(commitData);
+        expect(commitData).toMatchSnapshot(
+          `CommitDetails commitIndex: ${commitIndex}`
+        );
+      }
+      return null;
+    }
+
+    const rootID = store.roots[0];
+
+    for (let commitIndex = 0; commitIndex < 2; commitIndex++) {
+      utils.act(() => {
+        TestRenderer.create(
+          <Validator
+            commitIndex={commitIndex}
+            previousCommitDetails={null}
+            rootID={rootID}
+          />
+        );
+      });
+    }
+
+    expect(allCommitData).toHaveLength(2);
+
+    utils.exportImportHelper(bridge, store);
+
+    for (let commitIndex = 0; commitIndex < 2; commitIndex++) {
       utils.act(() => {
         TestRenderer.create(
           <Validator

--- a/src/__tests__/profilingCharts-test.js
+++ b/src/__tests__/profilingCharts-test.js
@@ -18,6 +18,7 @@ describe('profiling charts', () => {
 
     store = global.store;
     store.collapseNodesByDefault = false;
+    store.recordChangeDescriptions = true;
 
     React = require('react');
     ReactDOM = require('react-dom');

--- a/src/__tests__/profilingCommitTreeBuilder-test.js
+++ b/src/__tests__/profilingCommitTreeBuilder-test.js
@@ -17,6 +17,7 @@ describe('commit tree', () => {
 
     store = global.store;
     store.collapseNodesByDefault = false;
+    store.recordChangeDescriptions = true;
 
     React = require('react');
     ReactDOM = require('react-dom');

--- a/src/__tests__/storeComponentFilters-test.js
+++ b/src/__tests__/storeComponentFilters-test.js
@@ -21,6 +21,7 @@ describe('Store component filters', () => {
     store = global.store;
     store.collapseNodesByDefault = false;
     store.componentFilters = [];
+    store.recordChangeDescriptions = true;
 
     React = require('react');
     ReactDOM = require('react-dom');

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -6,6 +6,7 @@ import throttle from 'lodash.throttle';
 import {
   SESSION_STORAGE_LAST_SELECTION_KEY,
   SESSION_STORAGE_RELOAD_AND_PROFILE_KEY,
+  SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY,
   __DEBUG__,
 } from '../constants';
 import {
@@ -69,6 +70,7 @@ type PersistedSelection = {|
 export default class Agent extends EventEmitter {
   _bridge: Bridge;
   _isProfiling: boolean = false;
+  _recordChangeDescriptions: boolean = false;
   _rendererInterfaces: { [key: RendererID]: RendererInterface } = {};
   _persistedSelection: PersistedSelection | null = null;
   _persistedSelectionMatch: PathMatch | null = null;
@@ -79,8 +81,13 @@ export default class Agent extends EventEmitter {
     if (
       sessionStorageGetItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY) === 'true'
     ) {
+      this._recordChangeDescriptions =
+        sessionStorageGetItem(
+          SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY
+        ) === 'true';
       this._isProfiling = true;
 
+      sessionStorageRemoveItem(SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY);
       sessionStorageRemoveItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY);
     }
 
@@ -250,8 +257,12 @@ export default class Agent extends EventEmitter {
     }
   };
 
-  reloadAndProfile = () => {
+  reloadAndProfile = (recordChangeDescriptions: boolean) => {
     sessionStorageSetItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY, 'true');
+    sessionStorageSetItem(
+      SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY,
+      recordChangeDescriptions ? 'true' : 'false'
+    );
 
     // This code path should only be hit if the shell has explicitly told the Store that it supports profiling.
     // In that case, the shell must also listen for this specific message to know when it needs to reload the app.
@@ -358,7 +369,7 @@ export default class Agent extends EventEmitter {
     this._rendererInterfaces[rendererID] = rendererInterface;
 
     if (this._isProfiling) {
-      rendererInterface.startProfiling();
+      rendererInterface.startProfiling(this._recordChangeDescriptions);
     }
 
     // When the renderer is attached, we need to tell it whether
@@ -397,13 +408,14 @@ export default class Agent extends EventEmitter {
     window.addEventListener('pointerup', this._onPointerUp, true);
   };
 
-  startProfiling = () => {
+  startProfiling = (recordChangeDescriptions: boolean) => {
+    this._recordChangeDescriptions = recordChangeDescriptions;
     this._isProfiling = true;
     for (let rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)
       ]: any): RendererInterface);
-      renderer.startProfiling();
+      renderer.startProfiling(recordChangeDescriptions);
     }
     this._bridge.send('profilingStatus', this._isProfiling);
   };
@@ -422,6 +434,7 @@ export default class Agent extends EventEmitter {
 
   stopProfiling = () => {
     this._isProfiling = false;
+    this._recordChangeDescriptions = false;
     for (let rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -704,6 +704,7 @@ export function attach(
     }
   }
 
+  // Differentiates between a null context value and no context.
   const NO_CONTEXT = {};
 
   function getContextsForFiber(fiber: Fiber): [Object, any] | null {
@@ -731,6 +732,9 @@ export function attach(
     }
   }
 
+  // Record all contexts at the time profiling is started.
+  // Fibers only store the current context value,
+  // so we need to track them separatenly in order to determine changed keys.
   function crawlToInitializeContextsMap(fiber: Fiber) {
     updateContextsForFiber(fiber);
     let current = fiber.child;
@@ -2390,6 +2394,9 @@ export function attach(
       );
 
       if (shouldRecordChangeDescriptions) {
+        // Record all contexts at the time profiling is started.
+        // Fibers only store the current context value,
+        // so we need to track them separatenly in order to determine changed keys.
         crawlToInitializeContextsMap(root.current);
       }
     });

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -112,11 +112,12 @@ export type ReactRenderer = {
   currentDispatcherRef?: {| current: null | Dispatcher |},
 };
 
-// TODO (change descriptions) Is it important to handle context?
+// TODO (change descriptions) Should we report changed hooks keys?
 export type ChangeDescription = {|
+  context: Array<string> | boolean | null,
   didHooksChange: boolean,
-  props: Array<string>,
-  state: Array<string>,
+  props: Array<string> | null,
+  state: Array<string> | null,
 |};
 
 export type CommitDataBackend = {|

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -112,7 +112,16 @@ export type ReactRenderer = {
   currentDispatcherRef?: {| current: null | Dispatcher |},
 };
 
+// TODO (change descriptions) Is it important to handle context?
+export type ChangeDescription = {|
+  didHooksChange: boolean,
+  props: Array<string>,
+  state: Array<string>,
+|};
+
 export type CommitDataBackend = {|
+  // Tuple of fiber ID and change description
+  changeDescriptions: Array<[number, ChangeDescription]> | null,
   duration: number,
   // Tuple of fiber ID and actual duration
   fiberActualDurations: Array<[number, number]>,
@@ -226,7 +235,7 @@ export type RendererInterface = {
   setInProps: (id: number, path: Array<string | number>, value: any) => void,
   setInState: (id: number, path: Array<string | number>, value: any) => void,
   setTrackedPath: (path: Array<PathFrame> | null) => void,
-  startProfiling: () => void,
+  startProfiling: (recordChangeDescriptions: boolean) => void,
   stopProfiling: () => void,
   updateComponentFilters: (somponentFilters: Array<ComponentFilter>) => void,
 };

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -116,6 +116,7 @@ export type ReactRenderer = {
 export type ChangeDescription = {|
   context: Array<string> | boolean | null,
   didHooksChange: boolean,
+  isFirstMount: boolean,
   props: Array<string> | null,
   state: Array<string> | null,
 |};

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -112,7 +112,6 @@ export type ReactRenderer = {
   currentDispatcherRef?: {| current: null | Dispatcher |},
 };
 
-// TODO (change descriptions) Should we report changed hooks keys?
 export type ChangeDescription = {|
   context: Array<string> | boolean | null,
   didHooksChange: boolean,

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,9 @@ export const LOCAL_STORAGE_FILTER_PREFERENCES_KEY =
 export const SESSION_STORAGE_LAST_SELECTION_KEY =
   'React::DevTools::lastSelection';
 
+export const SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY =
+  'React::DevTools::recordChangeDescriptions';
+
 export const SESSION_STORAGE_RELOAD_AND_PROFILE_KEY =
   'React::DevTools::reloadAndProfile';
 

--- a/src/devtools/ProfilerStore.js
+++ b/src/devtools/ProfilerStore.js
@@ -179,7 +179,7 @@ export default class ProfilerStore extends EventEmitter {
   }
 
   startProfiling(): void {
-    this._bridge.send('startProfiling');
+    this._bridge.send('startProfiling', this._store.recordChangeDescriptions);
 
     // Don't actually update the local profiling boolean yet!
     // Wait for onProfilingStatus() to confirm the status has changed.

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -38,6 +38,8 @@ const LOCAL_STORAGE_CAPTURE_SCREENSHOTS_KEY =
   'React::DevTools::captureScreenshots';
 const LOCAL_STORAGE_COLLAPSE_ROOTS_BY_DEFAULT_KEY =
   'React::DevTools::collapseNodesByDefault';
+const LOCAL_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY =
+  'React::DevTools::recordChangeDescriptions';
 
 type Config = {|
   isProfiling?: boolean,
@@ -83,6 +85,8 @@ export default class Store extends EventEmitter {
 
   _profilerStore: ProfilerStore;
 
+  _recordChangeDescriptions: boolean = false;
+
   // Incremented each time the store is mutated.
   // This enables a passive effect to detect a mutation between render and commit phase.
   _revision: number = 0;
@@ -117,6 +121,10 @@ export default class Store extends EventEmitter {
     this._collapseNodesByDefault =
       localStorageGetItem(LOCAL_STORAGE_COLLAPSE_ROOTS_BY_DEFAULT_KEY) !==
       'false';
+
+    this._recordChangeDescriptions =
+      localStorageGetItem(LOCAL_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY) ===
+      'true';
 
     this._componentFilters = getSavedComponentFilters();
 
@@ -246,6 +254,20 @@ export default class Store extends EventEmitter {
 
   get profilerStore(): ProfilerStore {
     return this._profilerStore;
+  }
+
+  get recordChangeDescriptions(): boolean {
+    return this._recordChangeDescriptions;
+  }
+  set recordChangeDescriptions(value: boolean): void {
+    this._recordChangeDescriptions = value;
+
+    localStorageSetItem(
+      LOCAL_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY,
+      value ? 'true' : 'false'
+    );
+
+    this.emit('recordChangeDescriptions');
   }
 
   get revision(): number {

--- a/src/devtools/views/Profiler/Profiler.css
+++ b/src/devtools/views/Profiler/Profiler.css
@@ -21,6 +21,7 @@
   flex-direction: column;
   flex: 1 1 100px;
   max-width: 300px;
+  overflow-x: hidden;
   border-left: 1px solid var(--color-border);
   border-top: 1px solid var(--color-border);
 }

--- a/src/devtools/views/Profiler/Profiler.css
+++ b/src/devtools/views/Profiler/Profiler.css
@@ -14,6 +14,7 @@
   display: flex;
   flex-direction: column;
   flex: 2 1 200px;
+  border-top: 1px solid var(--color-border);
 }
 
 .RightColumn {
@@ -61,7 +62,6 @@
   display: flex;
   align-items: center;
   border-bottom: 1px solid var(--color-border);
-  border-top: 1px solid var(--color-border);
 }
 
 .VRule {

--- a/src/devtools/views/Profiler/SidebarCommitInfo.css
+++ b/src/devtools/views/Profiler/SidebarCommitInfo.css
@@ -4,12 +4,12 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .Content {
   padding: 0.5rem;
   user-select: none;
-  border-top: 1px solid var(--color-border);
   overflow: auto;
 }
 

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
@@ -16,6 +16,9 @@
 .Component {
   flex: 1;
   color: var(--color-component-name);
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 .Component:before {
   white-space: nowrap;

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
@@ -56,3 +56,22 @@
 .CurrentCommit:focus {
   outline: none;
 }
+
+.WhatChangedItem {
+  margin-top: 0.25rem;
+}
+
+.WhatChangedKey {
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-small);
+  line-height: 1;
+}
+.WhatChangedKey:first-of-type::before {
+  content: ' (';
+}
+.WhatChangedKey::after {
+  content: ', ';
+}
+.WhatChangedKey:last-of-type::after {
+  content: ')';
+}

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
@@ -4,12 +4,12 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .Content {
   padding: 0.5rem;
   user-select: none;
-  border-top: 1px solid var(--color-border);
   overflow-y: auto;
 }
 

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -104,21 +104,33 @@ function WhatChanged({
 
   const changeDescription = changeDescriptions.get(fiberID);
   if (changeDescription == null) {
-    return null;
-  }
-
-  const changes = [];
-  if (changeDescription.didHooksChange) {
-    changes.push(
-      <div key="hooks" className={styles.WhatChangedItem}>
-        • Hooks
+    // This indicates that the component mounted during this commit
+    return (
+      <div className={styles.Content}>
+        <label className={styles.Label}>Why did this render?</label>
+        <div className={styles.WhatChangedItem}>
+          This is the first time the component rendered.
+        </div>
       </div>
     );
   }
-  if (changeDescription.props.length !== 0) {
+
+  const changes = [];
+
+  if (changeDescription.didHooksChange) {
+    changes.push(
+      <div key="hooks" className={styles.WhatChangedItem}>
+        • Hooks changed
+      </div>
+    );
+  }
+  if (
+    changeDescription.props !== null &&
+    changeDescription.props.length !== 0
+  ) {
     changes.push(
       <div key="props" className={styles.WhatChangedItem}>
-        • Props
+        • Props changed:
         {changeDescription.props.map(key => (
           <span key={key} className={styles.WhatChangedKey}>
             {key}
@@ -127,10 +139,13 @@ function WhatChanged({
       </div>
     );
   }
-  if (changeDescription.state.length !== 0) {
+  if (
+    changeDescription.state !== null &&
+    changeDescription.state.length !== 0
+  ) {
     changes.push(
       <div key="state" className={styles.WhatChangedItem}>
-        • State
+        • State changed:
         {changeDescription.state.map(key => (
           <span key={key} className={styles.WhatChangedKey}>
             {key}
@@ -141,12 +156,16 @@ function WhatChanged({
   }
 
   if (changes.length === 0) {
-    changes.push(<div className={styles.WhatChangedItem}>Nothing</div>);
+    changes.push(
+      <div key="nothing" className={styles.WhatChangedItem}>
+        The parent component rendered.
+      </div>
+    );
   }
 
   return (
     <div className={styles.Content}>
-      <label className={styles.Label}>What changed?</label>
+      <label className={styles.Label}>Why did this render?</label>
       {changes}
     </div>
   );

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -75,7 +75,11 @@ export default function SidebarSelectedFiberInfo(_: Props) {
         rootID={((rootID: any): number)}
       />
       <div className={styles.Content}>
-        <label className={styles.Label}>Rendered at</label>: {listItems}
+        {listItems.length > 0 && (
+          <Fragment>
+            <label className={styles.Label}>Rendered at</label>: {listItems}
+          </Fragment>
+        )}
       </div>
     </Fragment>
   );

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -80,6 +80,9 @@ export default function SidebarSelectedFiberInfo(_: Props) {
             <label className={styles.Label}>Rendered at</label>: {listItems}
           </Fragment>
         )}
+        {listItems.length === 0 && (
+          <div>Did not render during this profiling session.</div>
+        )}
       </div>
     </Fragment>
   );

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -30,7 +30,7 @@ export default function SidebarSelectedFiberInfo(_: Props) {
   });
 
   const listItems = [];
-  for (let i = 0; i < commitIndices.length; i += 2) {
+  for (let i = 0; i < commitIndices.length; i++) {
     const commitIndex = commitIndices[i];
 
     const { duration, timestamp } = profilerStore.getCommitData(

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Fragment, useContext } from 'react';
+import ProfilerStore from 'src/devtools/ProfilerStore';
 import { ProfilerContext } from './ProfilerContext';
 import { formatDuration, formatTime } from './utils';
 import { StoreContext } from '../context';
@@ -67,9 +68,86 @@ export default function SidebarSelectedFiberInfo(_: Props) {
           <ButtonIcon type="close" />
         </Button>
       </div>
+      <WhatChanged
+        commitIndex={((selectedCommitIndex: any): number)}
+        fiberID={((selectedFiberID: any): number)}
+        profilerStore={profilerStore}
+        rootID={((rootID: any): number)}
+      />
       <div className={styles.Content}>
         <label className={styles.Label}>Rendered at</label>: {listItems}
       </div>
     </Fragment>
+  );
+}
+
+type WhatChangedProps = {|
+  commitIndex: number,
+  fiberID: number,
+  profilerStore: ProfilerStore,
+  rootID: number,
+|};
+
+function WhatChanged({
+  commitIndex,
+  fiberID,
+  profilerStore,
+  rootID,
+}: WhatChangedProps) {
+  const { changeDescriptions } = profilerStore.getCommitData(
+    ((rootID: any): number),
+    commitIndex
+  );
+  if (changeDescriptions === null) {
+    return null;
+  }
+
+  const changeDescription = changeDescriptions.get(fiberID);
+  if (changeDescription == null) {
+    return null;
+  }
+
+  const changes = [];
+  if (changeDescription.didHooksChange) {
+    changes.push(
+      <div key="hooks" className={styles.WhatChangedItem}>
+        • Hooks
+      </div>
+    );
+  }
+  if (changeDescription.props.length !== 0) {
+    changes.push(
+      <div key="props" className={styles.WhatChangedItem}>
+        • Props
+        {changeDescription.props.map(key => (
+          <span key={key} className={styles.WhatChangedKey}>
+            {key}
+          </span>
+        ))}
+      </div>
+    );
+  }
+  if (changeDescription.state.length !== 0) {
+    changes.push(
+      <div key="state" className={styles.WhatChangedItem}>
+        • State
+        {changeDescription.state.map(key => (
+          <span key={key} className={styles.WhatChangedKey}>
+            {key}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (changes.length === 0) {
+    changes.push(<div className={styles.WhatChangedItem}>Nothing</div>);
+  }
+
+  return (
+    <div className={styles.Content}>
+      <label className={styles.Label}>What changed?</label>
+      {changes}
+    </div>
   );
 }

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -104,7 +104,10 @@ function WhatChanged({
 
   const changeDescription = changeDescriptions.get(fiberID);
   if (changeDescription == null) {
-    // This indicates that the component mounted during this commit
+    return null;
+  }
+
+  if (changeDescription.isFirstMount) {
     return (
       <div className={styles.Content}>
         <label className={styles.Label}>Why did this render?</label>
@@ -117,6 +120,29 @@ function WhatChanged({
 
   const changes = [];
 
+  if (changeDescription.context === true) {
+    changes.push(
+      <div key="context" className={styles.WhatChangedItem}>
+        • Context changed
+      </div>
+    );
+  } else if (
+    typeof changeDescription.context === 'object' &&
+    changeDescription.context !== null &&
+    changeDescription.context.length !== 0
+  ) {
+    changes.push(
+      <div key="context" className={styles.WhatChangedItem}>
+        • Context changed:
+        {changeDescription.context.map(key => (
+          <span key={key} className={styles.WhatChangedKey}>
+            {key}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
   if (changeDescription.didHooksChange) {
     changes.push(
       <div key="hooks" className={styles.WhatChangedItem}>
@@ -124,6 +150,7 @@ function WhatChanged({
       </div>
     );
   }
+
   if (
     changeDescription.props !== null &&
     changeDescription.props.length !== 0
@@ -139,6 +166,7 @@ function WhatChanged({
       </div>
     );
   }
+
   if (
     changeDescription.state !== null &&
     changeDescription.state.length !== 0

--- a/src/devtools/views/Profiler/types.js
+++ b/src/devtools/views/Profiler/types.js
@@ -31,7 +31,6 @@ export type SnapshotNode = {|
   type: ElementType,
 |};
 
-// TODO (change descriptions) Should we report changed hooks keys?
 export type ChangeDescription = {|
   context: Array<string> | boolean | null,
   didHooksChange: boolean,

--- a/src/devtools/views/Profiler/types.js
+++ b/src/devtools/views/Profiler/types.js
@@ -31,11 +31,12 @@ export type SnapshotNode = {|
   type: ElementType,
 |};
 
-// TODO (change descriptions) Is it important to handle context?
+// TODO (change descriptions) Should we report changed hooks keys?
 export type ChangeDescription = {|
+  context: Array<string> | boolean | null,
   didHooksChange: boolean,
-  props: Array<string>,
-  state: Array<string>,
+  props: Array<string> | null,
+  state: Array<string> | null,
 |};
 
 export type CommitDataFrontend = {|

--- a/src/devtools/views/Profiler/types.js
+++ b/src/devtools/views/Profiler/types.js
@@ -31,7 +31,17 @@ export type SnapshotNode = {|
   type: ElementType,
 |};
 
+// TODO (change descriptions) Is it important to handle context?
+export type ChangeDescription = {|
+  didHooksChange: boolean,
+  props: Array<string>,
+  state: Array<string>,
+|};
+
 export type CommitDataFrontend = {|
+  // Map of Fiber (ID) to a description of what changed in this commit.
+  changeDescriptions: Map<number, ChangeDescription> | null,
+
   // How long was this commit?
   duration: number,
 
@@ -93,6 +103,7 @@ export type ProfilingDataFrontend = {|
 |};
 
 export type CommitDataExport = {|
+  changeDescriptions: Array<[number, ChangeDescription]> | null,
   duration: number,
   // Tuple of fiber ID and actual duration
   fiberActualDurations: Array<[number, number]>,

--- a/src/devtools/views/Profiler/types.js
+++ b/src/devtools/views/Profiler/types.js
@@ -35,6 +35,7 @@ export type SnapshotNode = {|
 export type ChangeDescription = {|
   context: Array<string> | boolean | null,
   didHooksChange: boolean,
+  isFirstMount: boolean,
   props: Array<string> | null,
   state: Array<string> | null,
 |};

--- a/src/devtools/views/Profiler/utils.js
+++ b/src/devtools/views/Profiler/utils.js
@@ -58,6 +58,10 @@ export function prepareProfilingDataFrontendFromBackendAndStore(
 
         dataForRoots.set(rootID, {
           commitData: commitData.map((commitDataBackend, commitIndex) => ({
+            changeDescriptions:
+              commitDataBackend.changeDescriptions != null
+                ? new Map(commitDataBackend.changeDescriptions)
+                : null,
             duration: commitDataBackend.duration,
             fiberActualDurations: new Map(
               commitDataBackend.fiberActualDurations
@@ -109,6 +113,7 @@ export function prepareProfilingDataFrontendFromExport(
       dataForRoots.set(rootID, {
         commitData: commitData.map(
           ({
+            changeDescriptions,
             duration,
             fiberActualDurations,
             fiberSelfDurations,
@@ -117,6 +122,8 @@ export function prepareProfilingDataFrontendFromExport(
             screenshot,
             timestamp,
           }) => ({
+            changeDescriptions:
+              changeDescriptions != null ? new Map(changeDescriptions) : null,
             duration,
             fiberActualDurations: new Map(fiberActualDurations),
             fiberSelfDurations: new Map(fiberSelfDurations),
@@ -159,6 +166,7 @@ export function prepareProfilingDataExport(
       dataForRoots.push({
         commitData: commitData.map(
           ({
+            changeDescriptions,
             duration,
             fiberActualDurations,
             fiberSelfDurations,
@@ -167,6 +175,10 @@ export function prepareProfilingDataExport(
             screenshot,
             timestamp,
           }) => ({
+            changeDescriptions:
+              changeDescriptions != null
+                ? Array.from(changeDescriptions.entries())
+                : null,
             duration,
             fiberActualDurations: Array.from(fiberActualDurations.entries()),
             fiberSelfDurations: Array.from(fiberSelfDurations.entries()),

--- a/src/devtools/views/Settings/Settings.js
+++ b/src/devtools/views/Settings/Settings.js
@@ -174,7 +174,7 @@ function Settings(_: {||}) {
             checked={recordChangeDescriptions}
             onChange={updateRecordChangeDescriptions}
           />{' '}
-          Record which props/state/hooks changed while profiling
+          Record why each component rendered while profiling.
         </label>
 
         {store.supportsCaptureScreenshots && (

--- a/src/devtools/views/Settings/Settings.js
+++ b/src/devtools/views/Settings/Settings.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, { Fragment, useCallback, useContext, useMemo } from 'react';
 import { useSubscription } from '../hooks';
 import { StoreContext } from '../context';
 import { SettingsContext } from './SettingsContext';
@@ -43,6 +43,20 @@ function Settings(_: {||}) {
     collapseNodesByDefaultSubscription
   );
 
+  const recordChangeDescriptionsSubscription = useMemo(
+    () => ({
+      getCurrentValue: () => store.recordChangeDescriptions,
+      subscribe: (callback: Function) => {
+        store.addListener('recordChangeDescriptions', callback);
+        return () => store.removeListener('recordChangeDescriptions', callback);
+      },
+    }),
+    [store]
+  );
+  const recordChangeDescriptions = useSubscription<boolean, Store>(
+    recordChangeDescriptionsSubscription
+  );
+
   const updateDisplayDensity = useCallback(
     ({ currentTarget }) => {
       setDisplayDensity(currentTarget.value);
@@ -66,6 +80,12 @@ function Settings(_: {||}) {
   const updateCollapseNodesByDefault = useCallback(
     ({ currentTarget }) => {
       store.collapseNodesByDefault = currentTarget.checked;
+    },
+    [store]
+  );
+  const updateRecordChangeDescriptions = useCallback(
+    ({ currentTarget }) => {
+      store.recordChangeDescriptions = currentTarget.checked;
     },
     [store]
   );
@@ -145,25 +165,37 @@ function Settings(_: {||}) {
         </label>
       </div>
 
-      {store.supportsCaptureScreenshots && (
-        <div className={styles.Section}>
-          <div className={styles.Header}>Profiler</div>
-          <label className={styles.CheckboxOption}>
-            <input
-              type="checkbox"
-              checked={captureScreenshots}
-              onChange={updateCaptureScreenshotsWhileProfiling}
-            />{' '}
-            Capture screenshots while profiling
-          </label>
-          {captureScreenshots && (
-            <div className={styles.ScreenshotThrottling}>
-              Screenshots will be throttled in order to reduce the negative
-              impact on performance.
-            </div>
-          )}
-        </div>
-      )}
+      <div className={styles.Section}>
+        <div className={styles.Header}>Profiler</div>
+
+        <label className={styles.CheckboxOption}>
+          <input
+            type="checkbox"
+            checked={recordChangeDescriptions}
+            onChange={updateRecordChangeDescriptions}
+          />{' '}
+          Record which props/state/hooks changed while profiling
+        </label>
+
+        {store.supportsCaptureScreenshots && (
+          <Fragment>
+            <label className={styles.CheckboxOption}>
+              <input
+                type="checkbox"
+                checked={captureScreenshots}
+                onChange={updateCaptureScreenshotsWhileProfiling}
+              />{' '}
+              Capture screenshots while profiling
+            </label>
+            {captureScreenshots && (
+              <div className={styles.ScreenshotThrottling}>
+                Screenshots will be throttled in order to reduce the negative
+                impact on performance.
+              </div>
+            )}
+          </Fragment>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
I'm exploring how the Profiler UI might help answer the question: Why did <some component> re-render?

### New preference added
<img width="345" alt="Profiler change tracking preference" src="https://user-images.githubusercontent.com/29597/59140022-471bc480-894d-11e9-8aab-6c53e3a8b1fb.png">

### A component mounted
<img width="300" alt="A component was mounted" src="https://user-images.githubusercontent.com/29597/59140025-50a52c80-894d-11e9-92ff-7611721a0662.png">

### A component updated
<img width="299" alt="A component's props and state changed" src="https://user-images.githubusercontent.com/29597/59140029-58fd6780-894d-11e9-8b86-75316401e5b6.png">
