### PR TITLE
Make children selection lighter

### DIFF
--- a/src/devtools/views/root.css
+++ b/src/devtools/views/root.css
@@ -56,7 +56,7 @@
   --light-color-scroll-track: #fafafa;
   --light-color-search-match: yellow;
   --light-color-search-match-current: #f7923b;
-  --light-color-selected-tree-highlight-active: rgba(0, 136, 250, 0.15);
+  --light-color-selected-tree-highlight-active: rgba(0, 136, 250, 0.1);
   --light-color-selected-tree-highlight-inactive: rgba(0, 0, 0, 0.05);
   --light-color-tab-selected-border: #0088fa;
   --light-color-text: #000000;


### PR DESCRIPTION
Nitpicking.

I prefer it lighter because it leaves more contrast and subjectively makes it easier to read the names.

![](https://d1sz9tkli0lfjq.cloudfront.net/items/341k1Y3w0l0u011H3u1L/Screen%20Recording%202019-06-11%20at%2005.54%20AM.gif?v=b2f22a5c)