### PR TITLE
Fix owner tree for legacy backend

### DIFF
--- a/src/backend/legacy/renderer.js
+++ b/src/backend/legacy/renderer.js
@@ -586,7 +586,9 @@ export function attach(
               id: getID(owner),
               type: getElementType(owner),
             });
-            owner = owner.owner;
+            if (owner._currentElement) {
+              owner = owner._currentElement._owner;
+            }
           }
         }
       }


### PR DESCRIPTION
It only went one lever deep because we read the field wrong.