### PR TITLE
Lazily send props/state/hooks across the bridge

### DIFF
--- a/shells/dev/app/Hydration/index.js
+++ b/shells/dev/app/Hydration/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useDebugValue, useState } from 'react';
+import React, { Fragment, useDebugValue, useState } from 'react';
 
 const div = document.createElement('div');
 const exmapleFunction = () => {};
@@ -92,23 +92,42 @@ function useInnerBaz() {
 
 export default function Hydration() {
   return (
-    <ChildComponent
-      html_element={div}
-      fn={exmapleFunction}
-      symbol={Symbol('symbol')}
-      react_element={<span />}
-      array_buffer={typedArray.buffer}
-      typed_array={typedArray}
-      date={new Date()}
-      array={arrayOfArrays}
-      object={objectOfObjects}
-    />
+    <Fragment>
+      <h1>Hydration</h1>
+      <DehydratableProps
+        html_element={div}
+        fn={exmapleFunction}
+        symbol={Symbol('symbol')}
+        react_element={<span />}
+        array_buffer={typedArray.buffer}
+        typed_array={typedArray}
+        date={new Date()}
+        array={arrayOfArrays}
+        object={objectOfObjects}
+      />
+      <DeepHooks />
+    </Fragment>
   );
 }
 
-function ChildComponent(props: any) {
-  useOuterFoo();
-  useOuterBar();
-  useOuterBaz();
-  return null;
+function DehydratableProps({ array, object }: any) {
+  return (
+    <ul>
+      <li>array: {JSON.stringify(array, null, 2)}</li>
+      <li>object: {JSON.stringify(object, null, 2)}</li>
+    </ul>
+  );
+}
+
+function DeepHooks(props: any) {
+  const foo = useOuterFoo();
+  const bar = useOuterBar();
+  const baz = useOuterBaz();
+  return (
+    <ul>
+      <li>foo: {foo}</li>
+      <li>bar: {bar}</li>
+      <li>baz: {baz}</li>
+    </ul>
+  );
 }

--- a/shells/dev/app/InspectableElements/Hydration.js
+++ b/shells/dev/app/InspectableElements/Hydration.js
@@ -13,6 +13,7 @@ const arrayOfArrays = [
   [['a', 'b', 'c'], ['d', 'e', 'f'], ['h', 'i', 'j']],
   [['k', 'l', 'm'], ['n', 'o', 'p'], ['q', 'r', 's']],
   [['t', 'u', 'v'], ['w', 'x', 'y'], ['z']],
+  [],
 ];
 
 const objectOfObjects = {
@@ -31,6 +32,7 @@ const objectOfObjects = {
     i: 8,
     j: 9,
   },
+  qux: {},
 };
 
 export default function Hydration() {

--- a/shells/dev/app/InspectableElements/Hydration.js
+++ b/shells/dev/app/InspectableElements/Hydration.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useDebugValue, useState } from 'react';
 
 const div = document.createElement('div');
 const exmapleFunction = () => {};
@@ -35,6 +35,61 @@ const objectOfObjects = {
   qux: {},
 };
 
+function useOuterFoo() {
+  useDebugValue({
+    debugA: {
+      debugB: {
+        debugC: 'abc',
+      },
+    },
+  });
+  useState({
+    valueA: {
+      valueB: {
+        valueC: 'abc',
+      },
+    },
+  });
+  return useInnerFoo();
+}
+
+function useInnerFoo() {
+  const [value] = useState([[['a', 'b', 'c']]]);
+  return value;
+}
+
+function useOuterBar() {
+  useDebugValue({
+    debugA: {
+      debugB: {
+        debugC: 'abc',
+      },
+    },
+  });
+  return useInnerBar();
+}
+
+function useInnerBar() {
+  useDebugValue({
+    debugA: {
+      debugB: {
+        debugC: 'abc',
+      },
+    },
+  });
+  const [count] = useState(123);
+  return count;
+}
+
+function useOuterBaz() {
+  return useInnerBaz();
+}
+
+function useInnerBaz() {
+  const [count] = useState(123);
+  return count;
+}
+
 export default function Hydration() {
   return (
     <ChildComponent
@@ -52,5 +107,8 @@ export default function Hydration() {
 }
 
 function ChildComponent(props: any) {
+  useOuterFoo();
+  useOuterBar();
+  useOuterBaz();
   return null;
 }

--- a/shells/dev/app/InspectableElements/Hydration.js
+++ b/shells/dev/app/InspectableElements/Hydration.js
@@ -1,0 +1,54 @@
+// @flow
+
+import React from 'react';
+
+const div = document.createElement('div');
+const exmapleFunction = () => {};
+const typedArray = new Uint8Array(3);
+typedArray[0] = 1;
+typedArray[1] = 2;
+typedArray[2] = 3;
+
+const arrayOfArrays = [
+  [['a', 'b', 'c'], ['d', 'e', 'f'], ['h', 'i', 'j']],
+  [['k', 'l', 'm'], ['n', 'o', 'p'], ['q', 'r', 's']],
+  [['t', 'u', 'v'], ['w', 'x', 'y'], ['z']],
+];
+
+const objectOfObjects = {
+  foo: {
+    a: 1,
+    b: 2,
+    c: 3,
+  },
+  bar: {
+    e: 4,
+    f: 5,
+    g: 6,
+  },
+  baz: {
+    h: 7,
+    i: 8,
+    j: 9,
+  },
+};
+
+export default function Hydration() {
+  return (
+    <ChildComponent
+      html_element={div}
+      fn={exmapleFunction}
+      symbol={Symbol('symbol')}
+      react_element={<span />}
+      array_buffer={typedArray.buffer}
+      typed_array={typedArray}
+      date={new Date()}
+      array={arrayOfArrays}
+      object={objectOfObjects}
+    />
+  );
+}
+
+function ChildComponent(props: any) {
+  return null;
+}

--- a/shells/dev/app/InspectableElements/InspectableElements.js
+++ b/shells/dev/app/InspectableElements/InspectableElements.js
@@ -4,6 +4,7 @@ import React, { Fragment } from 'react';
 import Contexts from './Contexts';
 import CustomHooks from './CustomHooks';
 import CustomObject from './CustomObject';
+import Hydration from './Hydration';
 import NestedProps from './NestedProps';
 
 // TODO Add Immutable JS example
@@ -16,6 +17,7 @@ export default function InspectableElements() {
       <Contexts />
       <CustomHooks />
       <CustomObject />
+      <Hydration />
     </Fragment>
   );
 }

--- a/shells/dev/app/InspectableElements/InspectableElements.js
+++ b/shells/dev/app/InspectableElements/InspectableElements.js
@@ -4,7 +4,6 @@ import React, { Fragment } from 'react';
 import Contexts from './Contexts';
 import CustomHooks from './CustomHooks';
 import CustomObject from './CustomObject';
-import Hydration from './Hydration';
 import NestedProps from './NestedProps';
 
 // TODO Add Immutable JS example
@@ -17,7 +16,6 @@ export default function InspectableElements() {
       <Contexts />
       <CustomHooks />
       <CustomObject />
-      <Hydration />
     </Fragment>
   );
 }

--- a/shells/dev/app/index.js
+++ b/shells/dev/app/index.js
@@ -10,6 +10,7 @@ import {
 import DeeplyNestedComponents from './DeeplyNestedComponents';
 import EditableProps from './EditableProps';
 import ElementTypes from './ElementTypes';
+import Hydration from './Hydration';
 import InspectableElements from './InspectableElements';
 import InteractionTracing from './InteractionTracing';
 import PriorityLevels from './PriorityLevels';
@@ -36,6 +37,7 @@ function mountTestApp() {
   mountHelper(ToDoList);
   mountHelper(InteractionTracing);
   mountHelper(InspectableElements);
+  mountHelper(Hydration);
   mountHelper(ElementTypes);
   mountHelper(EditableProps);
   mountHelper(PriorityLevels);

--- a/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -107,7 +107,7 @@ exports[`InspectedElementContext should inspect the currently selected element: 
       "isStateEditable": true,
       "name": "State",
       "value": 1,
-      "subHooks": {}
+      "subHooks": []
     }
   ],
   "props": {
@@ -124,7 +124,15 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
   "owners": null,
   "context": null,
   "events": null,
-  "hooks": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": {},
+      "subHooks": []
+    }
+  ],
   "props": {
     "nestedObject": {
       "a": {}
@@ -140,7 +148,15 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
   "owners": null,
   "context": null,
   "events": null,
-  "hooks": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": {},
+      "subHooks": []
+    }
+  ],
   "props": {
     "nestedObject": {
       "a": {
@@ -160,7 +176,15 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
   "owners": null,
   "context": null,
   "events": null,
-  "hooks": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": {},
+      "subHooks": []
+    }
+  ],
   "props": {
     "nestedObject": {
       "a": {
@@ -184,7 +208,93 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
   "owners": null,
   "context": null,
   "events": null,
-  "hooks": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": {},
+      "subHooks": []
+    }
+  ],
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": [
+            {
+              "d": {
+                "e": {}
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 5: Inspect hooks.0.value 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": {
+        "foo": {
+          "bar": {}
+        }
+      },
+      "subHooks": []
+    }
+  ],
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": [
+            {
+              "d": {
+                "e": {}
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 6: Inspect hooks.0.value.foo.bar 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": {
+        "foo": {
+          "bar": {
+            "baz": "hi"
+          }
+        }
+      },
+      "subHooks": []
+    }
+  ],
   "props": {
     "nestedObject": {
       "a": {
@@ -216,7 +326,7 @@ exports[`InspectedElementContext should not re-render a function with hooks if i
       "isStateEditable": true,
       "name": "State",
       "value": 0,
-      "subHooks": {}
+      "subHooks": []
     }
   ],
   "props": {
@@ -239,7 +349,7 @@ exports[`InspectedElementContext should not re-render a function with hooks if i
       "isStateEditable": true,
       "name": "State",
       "value": 0,
-      "subHooks": {}
+      "subHooks": []
     }
   ],
   "props": {

--- a/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -369,6 +369,7 @@ exports[`InspectedElementContext should not tear if hydration is requested after
   "hooks": null,
   "props": {
     "nestedObject": {
+      "value": 1,
       "a": {}
     }
   },
@@ -385,6 +386,7 @@ exports[`InspectedElementContext should not tear if hydration is requested after
   "hooks": null,
   "props": {
     "nestedObject": {
+      "value": 2,
       "a": {
         "value": 2,
         "b": {

--- a/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -1,11 +1,101 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InspectedElementContext should inspect the currently selected element: 1: mount 1`] = `
-[root]
-    <Example>
+exports[`InspectedElementContext should include updates for nested values that were previously hydrated: 1: Initially inspect element 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {},
+      "c": {}
+    }
+  },
+  "state": null
+}
 `;
 
-exports[`InspectedElementContext should inspect the currently selected element: 2: Inspected element 2 1`] = `
+exports[`InspectedElementContext should include updates for nested values that were previously hydrated: 2: Inspect props.nestedObject.a 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "value": 1,
+        "b": {
+          "value": 1
+        }
+      },
+      "c": {}
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should include updates for nested values that were previously hydrated: 3: Inspect props.nestedObject.c 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "value": 1,
+        "b": {
+          "value": 1
+        }
+      },
+      "c": {
+        "value": 1,
+        "d": {
+          "value": 1,
+          "e": {}
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should include updates for nested values that were previously hydrated: 4: update inspected element 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "value": 2,
+        "b": {
+          "value": 2
+        }
+      },
+      "c": {
+        "value": 2,
+        "d": {
+          "value": 2,
+          "e": {}
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should inspect the currently selected element: 1: Inspected element 2 1`] = `
 {
   "id": 2,
   "owners": null,
@@ -17,75 +107,18 @@ exports[`InspectedElementContext should inspect the currently selected element: 
       "isStateEditable": true,
       "name": "State",
       "value": 1,
-      "subHooks": []
+      "subHooks": {}
     }
   ],
   "props": {
-    "foo": 1,
-    "bar": "abc"
+    "a": 1,
+    "b": "abc"
   },
   "state": null
 }
 `;
 
-exports[`InspectedElementContext should not re-render a function with hooks if it did not update since it was last inspected: 1: mount 1`] = `
-[root]
-  ▾ <Wrapper>
-      <Anonymous>
-`;
-
-exports[`InspectedElementContext should not re-render a function with hooks if it did not update since it was last inspected: 2: initial render 1`] = `
-{
-  "id": 3,
-  "owners": null,
-  "context": null,
-  "events": null,
-  "hooks": [
-    {
-      "id": 0,
-      "isStateEditable": true,
-      "name": "State",
-      "value": 0,
-      "subHooks": []
-    }
-  ],
-  "props": {
-    "foo": 1,
-    "bar": "abc"
-  },
-  "state": null
-}
-`;
-
-exports[`InspectedElementContext should not re-render a function with hooks if it did not update since it was last inspected: 3: updated state 1`] = `
-{
-  "id": 3,
-  "owners": null,
-  "context": null,
-  "events": null,
-  "hooks": [
-    {
-      "id": 0,
-      "isStateEditable": true,
-      "name": "State",
-      "value": 0,
-      "subHooks": []
-    }
-  ],
-  "props": {
-    "foo": 2,
-    "bar": "def"
-  },
-  "state": null
-}
-`;
-
-exports[`InspectedElementContext should poll for updates for the currently selected element: 1: mount 1`] = `
-[root]
-    <Example>
-`;
-
-exports[`InspectedElementContext should poll for updates for the currently selected element: 2: initial render 1`] = `
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 1: Initially inspect element 1`] = `
 {
   "id": 2,
   "owners": null,
@@ -93,8 +126,177 @@ exports[`InspectedElementContext should poll for updates for the currently selec
   "events": null,
   "hooks": null,
   "props": {
-    "foo": 1,
-    "bar": "abc"
+    "nestedObject": {
+      "a": {}
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 2: Inspect props.nestedObject.a 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": {}
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 3: Inspect props.nestedObject.a.b.c 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": [
+            {
+              "d": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 4: Inspect props.nestedObject.a.b.c.0.d 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": [
+            {
+              "d": {
+                "e": {}
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not re-render a function with hooks if it did not update since it was last inspected: 1: initial render 1`] = `
+{
+  "id": 3,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": 0,
+      "subHooks": {}
+    }
+  ],
+  "props": {
+    "a": 1,
+    "b": "abc"
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not re-render a function with hooks if it did not update since it was last inspected: 2: updated state 1`] = `
+{
+  "id": 3,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": [
+    {
+      "id": 0,
+      "isStateEditable": true,
+      "name": "State",
+      "value": 0,
+      "subHooks": {}
+    }
+  ],
+  "props": {
+    "a": 2,
+    "b": "def"
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not tear if hydration is requested after an update: 1: Initially inspect element 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {}
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should not tear if hydration is requested after an update: 2: Inspect props.nestedObject.a 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "value": 2,
+        "b": {
+          "value": 2
+        }
+      }
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should poll for updates for the currently selected element: 1: initial render 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "a": 1,
+    "b": "abc"
   },
   "state": null
 }
@@ -108,19 +310,34 @@ exports[`InspectedElementContext should poll for updates for the currently selec
   "events": null,
   "hooks": null,
   "props": {
-    "foo": 2,
-    "bar": "def"
+    "a": 2,
+    "b": "def"
   },
   "state": null
 }
 `;
 
-exports[`InspectedElementContext should support custom objects with enumerable properties and getters: 1: mount 1`] = `
-[root]
-    <Example>
+exports[`InspectedElementContext should support complex data types: 1: Inspected element 2 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "events": null,
+  "hooks": null,
+  "props": {
+    "html_element": {},
+    "fn": {},
+    "symbol": {},
+    "react_element": {},
+    "array_buffer": {},
+    "typed_array": {},
+    "date": {}
+  },
+  "state": null
+}
 `;
 
-exports[`InspectedElementContext should support custom objects with enumerable properties and getters: 2: Inspected element 2 1`] = `
+exports[`InspectedElementContext should support custom objects with enumerable properties and getters: 1: Inspected element 2 1`] = `
 {
   "id": 2,
   "owners": null,

--- a/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -129,7 +129,9 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
       "id": 0,
       "isStateEditable": true,
       "name": "State",
-      "value": {},
+      "value": {
+        "foo": {}
+      },
       "subHooks": []
     }
   ],
@@ -153,7 +155,9 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
       "id": 0,
       "isStateEditable": true,
       "name": "State",
-      "value": {},
+      "value": {
+        "foo": {}
+      },
       "subHooks": []
     }
   ],
@@ -181,7 +185,9 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
       "id": 0,
       "isStateEditable": true,
       "name": "State",
-      "value": {},
+      "value": {
+        "foo": {}
+      },
       "subHooks": []
     }
   ],
@@ -213,7 +219,9 @@ exports[`InspectedElementContext should not dehydrate nested values until explic
       "id": 0,
       "isStateEditable": true,
       "name": "State",
-      "value": {},
+      "value": {
+        "foo": {}
+      },
       "subHooks": []
     }
   ],

--- a/src/__tests__/inspectedElementContext-test.js
+++ b/src/__tests__/inspectedElementContext-test.js
@@ -315,18 +315,24 @@ describe('InspectedElementContext', () => {
       typed_array,
       date,
     } = (inspectedElement: any).props;
+    expect(html_element[meta.inspectable]).toBe(false);
     expect(html_element[meta.name]).toBe('DIV');
     expect(html_element[meta.type]).toBe('html_element');
+    expect(fn[meta.inspectable]).toBe(false);
     expect(fn[meta.name]).toBe('exmapleFunction');
     expect(fn[meta.type]).toBe('function');
+    expect(symbol[meta.inspectable]).toBe(false);
     expect(symbol[meta.name]).toBe('Symbol(symbol)');
     expect(symbol[meta.type]).toBe('symbol');
+    expect(react_element[meta.inspectable]).toBe(false);
     expect(react_element[meta.name]).toBe('span');
     expect(react_element[meta.type]).toBe('react_element');
-    expect(array_buffer[meta.meta].length).toBe(3);
+    expect(array_buffer[meta.size]).toBe(3);
+    expect(array_buffer[meta.inspectable]).toBe(false);
     expect(array_buffer[meta.name]).toBe('ArrayBuffer');
     expect(array_buffer[meta.type]).toBe('array_buffer');
-    expect(typed_array[meta.meta].length).toBe(3);
+    expect(typed_array[meta.size]).toBe(3);
+    expect(typed_array[meta.inspectable]).toBe(false);
     expect(typed_array[meta.name]).toBe('Uint8Array');
     expect(typed_array[meta.type]).toBe('typed_array');
     expect(date[meta.type]).toBe('date');

--- a/src/__tests__/inspectedElementContext-test.js
+++ b/src/__tests__/inspectedElementContext-test.js
@@ -613,7 +613,7 @@ describe('InspectedElementContext', () => {
 
     TestUtils.act(() => {
       inspectedElement = null;
-      jest.runOnlyPendingTimers();
+      jest.advanceTimersByTime(1000);
       expect(inspectedElement).not.toBeNull();
       expect(inspectedElement).toMatchSnapshot('4: update inspected element');
     });

--- a/src/__tests__/inspectedElementContext-test.js
+++ b/src/__tests__/inspectedElementContext-test.js
@@ -335,6 +335,7 @@ describe('InspectedElementContext', () => {
     expect(typed_array[meta.inspectable]).toBe(false);
     expect(typed_array[meta.name]).toBe('Uint8Array');
     expect(typed_array[meta.type]).toBe('typed_array');
+    expect(date[meta.inspectable]).toBe(false);
     expect(date[meta.type]).toBe('date');
 
     done();

--- a/src/__tests__/inspectedElementContext-test.js
+++ b/src/__tests__/inspectedElementContext-test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import typeof ReactTestRenderer from 'react-test-renderer';
-import type { GetPath } from 'src/devtools/views/Components/InspectedElementContext';
+import type { GetInspectedElementPath } from 'src/devtools/views/Components/InspectedElementContext';
 import type Bridge from 'src/bridge';
 import type Store from 'src/devtools/store';
 
@@ -81,8 +81,8 @@ describe('InspectedElementContext', () => {
     let didFinish = false;
 
     function Suspender({ target }) {
-      const { read } = React.useContext(InspectedElementContext);
-      const inspectedElement = read(id);
+      const { getInspectedElement } = React.useContext(InspectedElementContext);
+      const inspectedElement = getInspectedElement(id);
       expect(inspectedElement).toMatchSnapshot(`1: Inspected element ${id}`);
       didFinish = true;
       return null;
@@ -121,8 +121,8 @@ describe('InspectedElementContext', () => {
     let inspectedElement = null;
 
     function Suspender({ target }) {
-      const { read } = React.useContext(InspectedElementContext);
-      inspectedElement = read(id);
+      const { getInspectedElement } = React.useContext(InspectedElementContext);
+      inspectedElement = getInspectedElement(id);
       return null;
     }
 
@@ -189,8 +189,8 @@ describe('InspectedElementContext', () => {
     let inspectedElement = null;
 
     function Suspender({ target }) {
-      const { read } = React.useContext(InspectedElementContext);
-      inspectedElement = read(target);
+      const { getInspectedElement } = React.useContext(InspectedElementContext);
+      inspectedElement = getInspectedElement(target);
       return null;
     }
 
@@ -283,8 +283,8 @@ describe('InspectedElementContext', () => {
     let inspectedElement = null;
 
     function Suspender({ target }) {
-      const { read } = React.useContext(InspectedElementContext);
-      inspectedElement = read(id);
+      const { getInspectedElement } = React.useContext(InspectedElementContext);
+      inspectedElement = getInspectedElement(id);
       return null;
     }
 
@@ -371,8 +371,8 @@ describe('InspectedElementContext', () => {
     let didFinish = false;
 
     function Suspender({ target }) {
-      const { read } = React.useContext(InspectedElementContext);
-      const inspectedElement = read(id);
+      const { getInspectedElement } = React.useContext(InspectedElementContext);
+      const inspectedElement = getInspectedElement(id);
       expect(inspectedElement).toMatchSnapshot(`1: Inspected element ${id}`);
       didFinish = true;
       return null;
@@ -434,13 +434,13 @@ describe('InspectedElementContext', () => {
 
     const id = ((store.getElementIDAtIndex(0): any): number);
 
-    let getPath: GetPath = ((null: any): GetPath);
+    let getInspectedElementPath: GetInspectedElementPath = ((null: any): GetInspectedElementPath);
     let inspectedElement = null;
 
     function Suspender({ target }) {
       const context = React.useContext(InspectedElementContext);
-      getPath = context.getPath;
-      inspectedElement = context.read(target);
+      getInspectedElementPath = context.getInspectedElementPath;
+      inspectedElement = context.getInspectedElement(target);
       return null;
     }
 
@@ -458,13 +458,13 @@ describe('InspectedElementContext', () => {
         ),
       false
     );
-    expect(getPath).not.toBeNull();
+    expect(getInspectedElementPath).not.toBeNull();
     expect(inspectedElement).not.toBeNull();
     expect(inspectedElement).toMatchSnapshot('1: Initially inspect element');
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['props', 'nestedObject', 'a']);
+      getInspectedElementPath(id, ['props', 'nestedObject', 'a']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -472,7 +472,7 @@ describe('InspectedElementContext', () => {
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['props', 'nestedObject', 'a', 'b', 'c']);
+      getInspectedElementPath(id, ['props', 'nestedObject', 'a', 'b', 'c']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -482,7 +482,15 @@ describe('InspectedElementContext', () => {
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['props', 'nestedObject', 'a', 'b', 'c', 0, 'd']);
+      getInspectedElementPath(id, [
+        'props',
+        'nestedObject',
+        'a',
+        'b',
+        'c',
+        0,
+        'd',
+      ]);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -492,7 +500,7 @@ describe('InspectedElementContext', () => {
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['hooks', 0, 'value']);
+      getInspectedElementPath(id, ['hooks', 0, 'value']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -500,7 +508,7 @@ describe('InspectedElementContext', () => {
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['hooks', 0, 'value', 'foo', 'bar']);
+      getInspectedElementPath(id, ['hooks', 0, 'value', 'foo', 'bar']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -542,13 +550,13 @@ describe('InspectedElementContext', () => {
 
     const id = ((store.getElementIDAtIndex(0): any): number);
 
-    let getPath: GetPath = ((null: any): GetPath);
+    let getInspectedElementPath: GetInspectedElementPath = ((null: any): GetInspectedElementPath);
     let inspectedElement = null;
 
     function Suspender({ target }) {
       const context = React.useContext(InspectedElementContext);
-      getPath = context.getPath;
-      inspectedElement = context.read(id);
+      getInspectedElementPath = context.getInspectedElementPath;
+      inspectedElement = context.getInspectedElement(id);
       return null;
     }
 
@@ -566,13 +574,13 @@ describe('InspectedElementContext', () => {
         ),
       false
     );
-    expect(getPath).not.toBeNull();
+    expect(getInspectedElementPath).not.toBeNull();
     expect(inspectedElement).not.toBeNull();
     expect(inspectedElement).toMatchSnapshot('1: Initially inspect element');
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['props', 'nestedObject', 'a']);
+      getInspectedElementPath(id, ['props', 'nestedObject', 'a']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -580,7 +588,7 @@ describe('InspectedElementContext', () => {
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['props', 'nestedObject', 'c']);
+      getInspectedElementPath(id, ['props', 'nestedObject', 'c']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();
@@ -629,6 +637,7 @@ describe('InspectedElementContext', () => {
       ReactDOM.render(
         <Example
           nestedObject={{
+            value: 1,
             a: {
               value: 1,
               b: {
@@ -643,13 +652,13 @@ describe('InspectedElementContext', () => {
 
     const id = ((store.getElementIDAtIndex(0): any): number);
 
-    let getPath: GetPath = ((null: any): GetPath);
+    let getInspectedElementPath: GetInspectedElementPath = ((null: any): GetInspectedElementPath);
     let inspectedElement = null;
 
     function Suspender({ target }) {
       const context = React.useContext(InspectedElementContext);
-      getPath = context.getPath;
-      inspectedElement = context.read(id);
+      getInspectedElementPath = context.getInspectedElementPath;
+      inspectedElement = context.getInspectedElement(id);
       return null;
     }
 
@@ -667,7 +676,7 @@ describe('InspectedElementContext', () => {
         ),
       false
     );
-    expect(getPath).not.toBeNull();
+    expect(getInspectedElementPath).not.toBeNull();
     expect(inspectedElement).not.toBeNull();
     expect(inspectedElement).toMatchSnapshot('1: Initially inspect element');
 
@@ -675,6 +684,7 @@ describe('InspectedElementContext', () => {
       ReactDOM.render(
         <Example
           nestedObject={{
+            value: 2,
             a: {
               value: 2,
               b: {
@@ -689,7 +699,7 @@ describe('InspectedElementContext', () => {
 
     inspectedElement = null;
     TestUtils.act(() => {
-      getPath(id, ['props', 'nestedObject', 'a']);
+      getInspectedElementPath(id, ['props', 'nestedObject', 'a']);
       jest.runOnlyPendingTimers();
     });
     expect(inspectedElement).not.toBeNull();

--- a/src/__tests__/inspectedElementContext-test.js
+++ b/src/__tests__/inspectedElementContext-test.js
@@ -397,7 +397,17 @@ describe('InspectedElementContext', () => {
   });
 
   it('should not dehydrate nested values until explicitly requested', async done => {
-    const Example = () => null;
+    const Example = () => {
+      const [state] = React.useState({
+        foo: {
+          bar: {
+            baz: 'hi',
+          },
+        },
+      });
+
+      return state.foo.bar.baz;
+    };
 
     const container = document.createElement('div');
     await utils.actAsync(() =>
@@ -477,6 +487,24 @@ describe('InspectedElementContext', () => {
     expect(inspectedElement).not.toBeNull();
     expect(inspectedElement).toMatchSnapshot(
       '4: Inspect props.nestedObject.a.b.c.0.d'
+    );
+
+    inspectedElement = null;
+    TestUtils.act(() => {
+      getPath(id, ['hooks', 0, 'value']);
+      jest.runOnlyPendingTimers();
+    });
+    expect(inspectedElement).not.toBeNull();
+    expect(inspectedElement).toMatchSnapshot('5: Inspect hooks.0.value');
+
+    inspectedElement = null;
+    TestUtils.act(() => {
+      getPath(id, ['hooks', 0, 'value', 'foo', 'bar']);
+      jest.runOnlyPendingTimers();
+    });
+    expect(inspectedElement).not.toBeNull();
+    expect(inspectedElement).toMatchSnapshot(
+      '6: Inspect hooks.0.value.foo.bar'
     );
 
     done();

--- a/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
+++ b/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
@@ -1,0 +1,167 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InspectedElementContext should inspect the currently selected element: 1: Initial inspection 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "a": 1,
+    "b": "abc"
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 1: Initially inspect element 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {}
+    }
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 2: Inspect props.nestedObject.a 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": {}
+        }
+      }
+    }
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 3: Inspect props.nestedObject.a.b.c 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": [
+            {
+              "d": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should not dehydrate nested values until explicitly requested: 4: Inspect props.nestedObject.a.b.c.0.d 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "nestedObject": {
+      "a": {
+        "b": {
+          "c": [
+            {
+              "d": {
+                "e": {}
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should support complex data types: 1: Initial inspection 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "html_element": {},
+    "fn": {},
+    "symbol": {},
+    "react_element": {},
+    "array_buffer": {},
+    "typed_array": {},
+    "date": {}
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should support custom objects with enumerable properties and getters: 1: Initial inspection 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "events": null,
+  "hooks": null,
+  "props": {
+    "data": {
+      "_number": 42,
+      "number": 42
+    }
+  },
+  "state": null
+},
+}
+`;

--- a/src/__tests__/legacy/inspectElement-test.js
+++ b/src/__tests__/legacy/inspectElement-test.js
@@ -1,0 +1,233 @@
+// @flow
+
+import type { InspectedElementPayload } from 'src/backend/types';
+import type { DehydratedData } from 'src/devtools/views/Components/types';
+import type Bridge from 'src/bridge';
+import type Store from 'src/devtools/store';
+
+describe('InspectedElementContext', () => {
+  let React;
+  let ReactDOM;
+  let hydrate;
+  let meta;
+  let bridge: Bridge;
+  let store: Store;
+
+  const act = (callback: Function) => {
+    callback();
+
+    jest.runAllTimers(); // Flush Bridge operations
+  };
+
+  function dehydrateHelper(
+    dehydratedData: DehydratedData | null
+  ): Object | null {
+    if (dehydratedData !== null) {
+      return hydrate(dehydratedData.data, dehydratedData.cleaned);
+    } else {
+      return null;
+    }
+  }
+
+  async function read(
+    id: number,
+    path?: Array<string | number>
+  ): Promise<Object> {
+    return new Promise((resolve, reject) => {
+      const rendererID = ((store.getRendererIDForElement(id): any): number);
+
+      const onInspectedElement = (payload: InspectedElementPayload) => {
+        bridge.removeListener('inspectedElement', onInspectedElement);
+
+        if (payload.type === 'full-data' && payload.value !== null) {
+          payload.value.context = dehydrateHelper(payload.value.context);
+          payload.value.props = dehydrateHelper(payload.value.props);
+          payload.value.state = dehydrateHelper(payload.value.state);
+        }
+
+        resolve(payload);
+      };
+
+      bridge.addListener('inspectedElement', onInspectedElement);
+      bridge.send('inspectElement', { id, path, rendererID });
+
+      jest.runOnlyPendingTimers();
+    });
+  }
+
+  beforeEach(() => {
+    bridge = global.bridge;
+    store = global.store;
+
+    hydrate = require('src/hydration').hydrate;
+    meta = require('src/hydration').meta;
+
+    // Redirect all React/ReactDOM requires to the v15 UMD.
+    // We use the UMD because Jest doesn't enable us to mock deep imports (e.g. "react/lib/Something").
+    jest.mock('react', () => jest.requireActual('react-15/dist/react.js'));
+    jest.mock('react-dom', () =>
+      jest.requireActual('react-dom-15/dist/react-dom.js')
+    );
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+  });
+
+  it('should inspect the currently selected element', async done => {
+    const Example = () => null;
+
+    act(() =>
+      ReactDOM.render(<Example a={1} b="abc" />, document.createElement('div'))
+    );
+
+    const id = ((store.getElementIDAtIndex(0): any): number);
+    const inspectedElement = await read(id);
+
+    expect(inspectedElement).toMatchSnapshot('1: Initial inspection');
+
+    done();
+  });
+
+  it('should support complex data types', async done => {
+    const Example = () => null;
+
+    const div = document.createElement('div');
+    const exmapleFunction = () => {};
+    const typedArray = new Uint8Array(3);
+
+    act(() =>
+      ReactDOM.render(
+        <Example
+          html_element={div}
+          fn={exmapleFunction}
+          symbol={Symbol('symbol')}
+          react_element={<span />}
+          array_buffer={typedArray.buffer}
+          typed_array={typedArray}
+          date={new Date()}
+        />,
+        document.createElement('div')
+      )
+    );
+
+    const id = ((store.getElementIDAtIndex(0): any): number);
+    const inspectedElement = await read(id);
+
+    expect(inspectedElement).toMatchSnapshot('1: Initial inspection');
+
+    const {
+      html_element,
+      fn,
+      symbol,
+      react_element,
+      array_buffer,
+      typed_array,
+      date,
+    } = inspectedElement.value.props;
+    expect(html_element[meta.name]).toBe('DIV');
+    expect(html_element[meta.type]).toBe('html_element');
+    expect(fn[meta.name]).toBe('exmapleFunction');
+    expect(fn[meta.type]).toBe('function');
+    expect(symbol[meta.name]).toBe('Symbol(symbol)');
+    expect(symbol[meta.type]).toBe('symbol');
+    expect(react_element[meta.name]).toBe('span');
+    expect(react_element[meta.type]).toBe('react_element');
+    expect(array_buffer[meta.meta].length).toBe(3);
+    expect(array_buffer[meta.name]).toBe('ArrayBuffer');
+    expect(array_buffer[meta.type]).toBe('array_buffer');
+    expect(typed_array[meta.meta].length).toBe(3);
+    expect(typed_array[meta.name]).toBe('Uint8Array');
+    expect(typed_array[meta.type]).toBe('typed_array');
+    expect(date[meta.type]).toBe('date');
+
+    done();
+  });
+
+  it('should support custom objects with enumerable properties and getters', async done => {
+    class CustomData {
+      _number = 42;
+      get number() {
+        return this._number;
+      }
+      set number(value) {
+        this._number = value;
+      }
+    }
+
+    const descriptor = ((Object.getOwnPropertyDescriptor(
+      CustomData.prototype,
+      'number'
+    ): any): PropertyDescriptor<number>);
+    descriptor.enumerable = true;
+    Object.defineProperty(CustomData.prototype, 'number', descriptor);
+
+    const Example = ({ data }) => null;
+
+    act(() =>
+      ReactDOM.render(
+        <Example data={new CustomData()} />,
+        document.createElement('div')
+      )
+    );
+
+    const id = ((store.getElementIDAtIndex(0): any): number);
+    const inspectedElement = await read(id);
+
+    expect(inspectedElement).toMatchSnapshot('1: Initial inspection');
+
+    done();
+  });
+
+  it('should not dehydrate nested values until explicitly requested', async done => {
+    const Example = () => null;
+
+    act(() =>
+      ReactDOM.render(
+        <Example
+          nestedObject={{
+            a: {
+              b: {
+                c: [
+                  {
+                    d: {
+                      e: {},
+                    },
+                  },
+                ],
+              },
+            },
+          }}
+        />,
+        document.createElement('div')
+      )
+    );
+
+    const id = ((store.getElementIDAtIndex(0): any): number);
+
+    let inspectedElement = await read(id);
+    expect(inspectedElement).toMatchSnapshot('1: Initially inspect element');
+
+    inspectedElement = await read(id, ['props', 'nestedObject', 'a']);
+    expect(inspectedElement).toMatchSnapshot('2: Inspect props.nestedObject.a');
+
+    inspectedElement = await read(id, ['props', 'nestedObject', 'a', 'b', 'c']);
+    expect(inspectedElement).toMatchSnapshot(
+      '3: Inspect props.nestedObject.a.b.c'
+    );
+
+    inspectedElement = await read(id, [
+      'props',
+      'nestedObject',
+      'a',
+      'b',
+      'c',
+      0,
+      'd',
+    ]);
+    expect(inspectedElement).toMatchSnapshot(
+      '4: Inspect props.nestedObject.a.b.c.0.d'
+    );
+
+    done();
+  });
+});

--- a/src/__tests__/legacy/inspectElement-test.js
+++ b/src/__tests__/legacy/inspectElement-test.js
@@ -124,20 +124,27 @@ describe('InspectedElementContext', () => {
       typed_array,
       date,
     } = inspectedElement.value.props;
+    expect(html_element[meta.inspectable]).toBe(false);
     expect(html_element[meta.name]).toBe('DIV');
     expect(html_element[meta.type]).toBe('html_element');
+    expect(fn[meta.inspectable]).toBe(false);
     expect(fn[meta.name]).toBe('exmapleFunction');
     expect(fn[meta.type]).toBe('function');
+    expect(symbol[meta.inspectable]).toBe(false);
     expect(symbol[meta.name]).toBe('Symbol(symbol)');
     expect(symbol[meta.type]).toBe('symbol');
+    expect(react_element[meta.inspectable]).toBe(false);
     expect(react_element[meta.name]).toBe('span');
     expect(react_element[meta.type]).toBe('react_element');
     expect(array_buffer[meta.size]).toBe(3);
+    expect(array_buffer[meta.inspectable]).toBe(false);
     expect(array_buffer[meta.name]).toBe('ArrayBuffer');
     expect(array_buffer[meta.type]).toBe('array_buffer');
     expect(typed_array[meta.size]).toBe(3);
+    expect(typed_array[meta.inspectable]).toBe(false);
     expect(typed_array[meta.name]).toBe('Uint8Array');
     expect(typed_array[meta.type]).toBe('typed_array');
+    expect(date[meta.inspectable]).toBe(false);
     expect(date[meta.type]).toBe('date');
 
     done();

--- a/src/__tests__/legacy/inspectElement-test.js
+++ b/src/__tests__/legacy/inspectElement-test.js
@@ -132,10 +132,10 @@ describe('InspectedElementContext', () => {
     expect(symbol[meta.type]).toBe('symbol');
     expect(react_element[meta.name]).toBe('span');
     expect(react_element[meta.type]).toBe('react_element');
-    expect(array_buffer[meta.meta].length).toBe(3);
+    expect(array_buffer[meta.size]).toBe(3);
     expect(array_buffer[meta.name]).toBe('ArrayBuffer');
     expect(array_buffer[meta.type]).toBe('array_buffer');
-    expect(typed_array[meta.meta].length).toBe(3);
+    expect(typed_array[meta.size]).toBe(3);
     expect(typed_array[meta.name]).toBe('Uint8Array');
     expect(typed_array[meta.type]).toBe('typed_array');
     expect(date[meta.type]).toBe('date');

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -42,6 +42,12 @@ type ElementAndRendererID = {|
   rendererID: number,
 |};
 
+type InspectElementParams = {|
+  id: number,
+  path?: Array<string | number>,
+  rendererID: number,
+|};
+
 type OverrideHookParams = {|
   id: number,
   hookID: number,
@@ -242,12 +248,12 @@ export default class Agent extends EventEmitter<{|
     }
   };
 
-  inspectElement = ({ id, rendererID }: ElementAndRendererID) => {
+  inspectElement = ({ id, path, rendererID }: InspectElementParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
-      this._bridge.send('inspectedElement', renderer.inspectElement(id));
+      this._bridge.send('inspectedElement', renderer.inspectElement(id, path));
     }
   };
 

--- a/src/backend/legacy/renderer.js
+++ b/src/backend/legacy/renderer.js
@@ -562,6 +562,24 @@ export function attach(
     });
   }
 
+  function isKeyedPathWhitelisted(
+    key: string
+  ): (path: Array<string | number>) => boolean {
+    return (path: Array<string | number>) =>
+      isPathWhitelisted([key].concat(path));
+  }
+
+  function isPathWhitelisted(path: Array<string | number>): boolean {
+    let current = currentlyInspectedPaths;
+    for (let i = 0; i < path.length; i++) {
+      current = current[path[i]];
+      if (!current) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   function inspectElement(
     id: number,
     path?: Array<string | number>
@@ -585,15 +603,15 @@ export function attach(
 
     inspectedElement.context = cleanForBridge(
       inspectedElement.context,
-      currentlyInspectedPaths['context']
+      isKeyedPathWhitelisted('context')
     );
     inspectedElement.props = cleanForBridge(
       inspectedElement.props,
-      currentlyInspectedPaths['props']
+      isKeyedPathWhitelisted('props')
     );
     inspectedElement.state = cleanForBridge(
       inspectedElement.state,
-      currentlyInspectedPaths['state']
+      isKeyedPathWhitelisted('state')
     );
 
     return {

--- a/src/backend/legacy/renderer.js
+++ b/src/backend/legacy/renderer.js
@@ -562,22 +562,20 @@ export function attach(
     });
   }
 
-  function isKeyedPathWhitelisted(
-    key: string
-  ): (path: Array<string | number>) => boolean {
-    return (path: Array<string | number>) =>
-      isPathWhitelisted([key].concat(path));
-  }
-
-  function isPathWhitelisted(path: Array<string | number>): boolean {
-    let current = currentlyInspectedPaths;
-    for (let i = 0; i < path.length; i++) {
-      current = current[path[i]];
+  function createIsPathWhitelisted(key: string) {
+    return function isPathWhitelisted(path: Array<string | number>): boolean {
+      let current = currentlyInspectedPaths[key];
       if (!current) {
         return false;
       }
-    }
-    return true;
+      for (let i = 0; i < path.length; i++) {
+        current = current[path[i]];
+        if (!current) {
+          return false;
+        }
+      }
+      return true;
+    };
   }
 
   function inspectElement(
@@ -603,15 +601,15 @@ export function attach(
 
     inspectedElement.context = cleanForBridge(
       inspectedElement.context,
-      isKeyedPathWhitelisted('context')
+      createIsPathWhitelisted('context')
     );
     inspectedElement.props = cleanForBridge(
       inspectedElement.props,
-      isKeyedPathWhitelisted('props')
+      createIsPathWhitelisted('props')
     );
     inspectedElement.state = cleanForBridge(
       inspectedElement.state,
-      isKeyedPathWhitelisted('state')
+      createIsPathWhitelisted('state')
     );
 
     return {

--- a/src/backend/legacy/renderer.js
+++ b/src/backend/legacy/renderer.js
@@ -552,6 +552,8 @@ export function attach(
   let currentlyInspectedElementID: number | null = null;
   let currentlyInspectedPaths: Object = {};
 
+  // Track the intersection of currently inspected paths,
+  // so that we can send their data along if the element is re-rendered.
   function mergeInspectedPaths(path: Array<string | number>) {
     let current = currentlyInspectedPaths;
     path.forEach(key => {
@@ -563,6 +565,8 @@ export function attach(
   }
 
   function createIsPathWhitelisted(key: string) {
+    // This function helps prevent previously-inspected paths from being dehydrated in updates.
+    // This is important to avoid a bad user experience where expanded toggles collapse on update.
     return function isPathWhitelisted(path: Array<string | number>): boolean {
       let current = currentlyInspectedPaths[key];
       if (!current) {

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -2156,9 +2156,18 @@ export function attach(
       // Dehydrating the 'subHooks' property makes the HooksTree UI a lot more complicated,
       // so it's easiest for now if we just don't break on this boundary.
       // We can always dehydrate a level deeper (in the value object).
-      // TODO (hydration) This check depends on a LEVEL_THRESHOLD of 2 to avoid dehydrating a hook incorrectly.
-      if (isHooksPath && path[path.length - 1] === 'subHooks') {
-        return true;
+      if (isHooksPath) {
+        if (path.length === 1) {
+          // Never dehydrate the hooks object at the top level.
+          return true;
+        }
+        if (
+          path[path.length - 1] === 'subHooks' ||
+          path[path.length - 2] === 'subHooks'
+        ) {
+          // Never dehydrate the subHooks array
+          return true;
+        }
       }
 
       let current =

--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -2168,7 +2168,7 @@ export function attach(
               ((mostRecentlyInspectedElement: any): InspectedElement),
               path
             ),
-            mergeInspectedPaths,
+            currentlyInspectedPaths,
             path
           ),
         };

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -215,6 +215,40 @@ export type InspectedElement = {|
   type: ElementType,
 |};
 
+export const InspectElementFullDataType = 'full-data';
+export const InspectElementNoChangeType = 'no-change';
+export const InspectElementNotFoundType = 'not-found';
+export const InspectElementHydratedPathType = 'hydrated-path';
+
+type InspectElementFullData = {|
+  id: number,
+  type: 'full-data',
+  value: InspectedElement,
+|};
+
+type InspectElementHydratedPath = {|
+  id: number,
+  type: 'hydrated-path',
+  path: Array<string | number>,
+  value: any,
+|};
+
+type InspectElementNoChange = {|
+  id: number,
+  type: 'no-change',
+|};
+
+type InspectElementNotFound = {|
+  id: number,
+  type: 'not-found',
+|};
+
+export type InspectedElementPayload =
+  | InspectElementFullData
+  | InspectElementHydratedPath
+  | InspectElementNoChange
+  | InspectElementNotFound;
+
 export type RendererInterface = {
   cleanup: () => void,
   findNativeNodesForFiberID: FindNativeNodesForFiberID,
@@ -226,7 +260,10 @@ export type RendererInterface = {
   getPathForElement: (id: number) => Array<PathFrame> | null,
   handleCommitFiberRoot: (fiber: Object, commitPriority?: number) => void,
   handleCommitFiberUnmount: (fiber: Object) => void,
-  inspectElement: (id: number) => InspectedElement | number | null,
+  inspectElement: (
+    id: number,
+    path?: Array<string | number>
+  ) => InspectedElementPayload,
   logElementToConsole: (id: number) => void,
   overrideSuspense: (id: number, forceFallback: boolean) => void,
   prepareViewElementSource: (id: number) => void,

--- a/src/backend/utils.js
+++ b/src/backend/utils.js
@@ -6,14 +6,14 @@ import type { DehydratedData } from 'src/devtools/views/Components/types';
 
 export function cleanForBridge(
   data: Object | null,
-  inspectedPaths?: Object = {},
+  isPathWhitelisted: (path: Array<string | number>) => boolean,
   path?: Array<string | number> = []
 ): DehydratedData | null {
   if (data !== null) {
     const cleaned = [];
 
     return {
-      data: dehydrate(data, cleaned, path, inspectedPaths),
+      data: dehydrate(data, cleaned, path, isPathWhitelisted),
       cleaned,
     };
   } else {
@@ -27,6 +27,7 @@ export function copyWithSet(
   value: any,
   index: number = 0
 ): Object | Array<any> {
+  console.log('[utils] copyWithSet()', obj, path, index, value);
   if (index >= path.length) {
     return value;
   }

--- a/src/backend/utils.js
+++ b/src/backend/utils.js
@@ -4,12 +4,16 @@ import { dehydrate } from '../hydration';
 
 import type { DehydratedData } from 'src/devtools/views/Components/types';
 
-export function cleanForBridge(data: Object | null): DehydratedData | null {
+export function cleanForBridge(
+  data: Object | null,
+  inspectedPaths?: Object = {},
+  path?: Array<string | number> = []
+): DehydratedData | null {
   if (data !== null) {
     const cleaned = [];
 
     return {
-      data: dehydrate(data, cleaned),
+      data: dehydrate(data, cleaned, path, inspectedPaths),
       cleaned,
     };
   } else {
@@ -31,22 +35,4 @@ export function copyWithSet(
   // $FlowFixMe number or string is fine here
   updated[key] = copyWithSet(obj[key], path, value, index + 1);
   return updated;
-}
-
-export function setInObject(
-  object: Object,
-  path: Array<string | number>,
-  value: any
-) {
-  const last = path.pop();
-  if (object != null) {
-    const parent: Object = path.reduce(
-      // $FlowFixMe
-      (reduced, attribute) => reduced[attribute],
-      object
-    );
-    if (parent) {
-      parent[last] = value;
-    }
-  }
 }

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -4,7 +4,7 @@ import EventEmitter from 'events';
 
 import type { ComponentFilter, Wall } from './types';
 import type {
-  InspectedElement,
+  InspectedElementPayload,
   OwnersList,
   ProfilingDataBackend,
   RendererID,
@@ -43,6 +43,11 @@ type OverrideSuspense = {|
   forceFallback: boolean,
 |};
 
+type InspectElementParams = {|
+  ...ElementAndRendererID,
+  path?: Array<string | number>,
+|};
+
 export default class Bridge extends EventEmitter<{|
   captureScreenshot: [{| commitIndex: number, rootID: number |}],
   clearHighlightedElementInDOM: [],
@@ -51,8 +56,8 @@ export default class Bridge extends EventEmitter<{|
   getProfilingStatus: [],
   highlightElementInDOM: [HighlightElementInDOM],
   init: [],
-  inspectElement: [ElementAndRendererID],
-  inspectedElement: [InspectedElement | number | null],
+  inspectElement: [InspectElementParams],
+  inspectedElement: [InspectedElementPayload],
   isBackendStorageAPISupported: [boolean],
   logElementToConsole: [ElementAndRendererID],
   operations: [Uint32Array],

--- a/src/devtools/views/Components/ExpandCollapseToggle.js
+++ b/src/devtools/views/Components/ExpandCollapseToggle.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback } from 'react';
+import React from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 
@@ -15,14 +15,10 @@ export default function ExpandCollapseToggle({
   isOpen,
   setIsOpen,
 }: ExpandCollapseToggleProps) {
-  const handleClick = useCallback(() => {
-    setIsOpen(prevIsOpen => !prevIsOpen);
-  }, [setIsOpen]);
-
   return (
     <Button
       className={styles.ExpandCollapseToggle}
-      onClick={handleClick}
+      onClick={() => setIsOpen(prevIsOpen => !prevIsOpen)}
       title={`${isOpen ? 'Collapse' : 'Expand'} prop value`}
     >
       <ButtonIcon type={isOpen ? 'expanded' : 'collapsed'} />

--- a/src/devtools/views/Components/HooksTree.js
+++ b/src/devtools/views/Components/HooksTree.js
@@ -86,7 +86,7 @@ function HookView({ canEditHooks, hook, id, path = [] }: HookViewProps) {
 
   if (hook.hasOwnProperty(meta.inspected)) {
     // This Hook is too deep and hasn't been hydrated.
-    // TODO: show UI to load its data.
+    // TODO (hydration) show UI to load its data.
     return (
       <div className={styles.Hook}>
         <div className={styles.NameValueRow}>

--- a/src/devtools/views/Components/InspectedElementContext.js
+++ b/src/devtools/views/Components/InspectedElementContext.js
@@ -236,10 +236,21 @@ function InspectedElementContextController({ children }: Props) {
     // Update the $r variable.
     bridge.send('selectElement', { id: selectedElementID, rendererID });
 
-    const onInspectedElement = ({ id }: InspectedElementPayload) => {
+    const onInspectedElement = (data: InspectedElementPayload) => {
       // If this is the element we requested, wait a little bit and then ask for another update.
-      if (id === selectedElementID) {
-        timeoutID = setTimeout(sendRequest, 1000);
+      if (data.id === selectedElementID) {
+        switch (data.type) {
+          case 'no-change':
+          case 'full-data':
+          case 'hydrated-path':
+            if (timeoutID !== null) {
+              clearTimeout(timeoutID);
+            }
+            timeoutID = setTimeout(sendRequest, 1000);
+            break;
+          default:
+            break;
+        }
       }
     };
 

--- a/src/devtools/views/Components/InspectedElementTree.js
+++ b/src/devtools/views/Components/InspectedElementTree.js
@@ -8,10 +8,13 @@ import KeyValue from './KeyValue';
 import { serializeDataForCopy } from '../utils';
 import styles from './InspectedElementTree.css';
 
+import type { InspectPath } from './SelectedElement';
+
 type OverrideValueFn = (path: Array<string | number>, value: any) => void;
 
 type Props = {|
   data: Object | null,
+  inspectPath?: InspectPath,
   label: string,
   overrideValueFn?: ?OverrideValueFn,
   showWhenEmpty?: boolean,
@@ -19,6 +22,7 @@ type Props = {|
 
 export default function InspectedElementTree({
   data,
+  inspectPath,
   label,
   overrideValueFn,
   showWhenEmpty = false,
@@ -32,7 +36,6 @@ export default function InspectedElementTree({
   if (isEmpty && !showWhenEmpty) {
     return null;
   } else {
-    // TODO Add click and key handlers for toggling element open/close state.
     return (
       <div className={styles.InspectedElementTree}>
         <div className={styles.HeaderRow}>
@@ -49,6 +52,7 @@ export default function InspectedElementTree({
             <KeyValue
               key={name}
               depth={1}
+              inspectPath={inspectPath}
               name={name}
               overrideValueFn={overrideValueFn}
               path={[name]}

--- a/src/devtools/views/Components/KeyValue.css
+++ b/src/devtools/views/Components/KeyValue.css
@@ -21,7 +21,9 @@
 
 .Value {
   color: var(--color-attribute-value);
-  word-break: break-all;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .None {

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -19,6 +19,9 @@ type KeyValueProps = {|
   value: any,
 |};
 
+// TODO (hydration) Don't display meta objects.
+// Add event listener to request a "read" instead.
+
 export default function KeyValue({
   depth,
   hidden,
@@ -78,6 +81,7 @@ export default function KeyValue({
       </div>
     );
   } else if (value.hasOwnProperty(meta.type)) {
+    // TODO (hydration) show UI to load its data?
     // TODO Is this type even necessary? Can we just drop it?
     children = (
       <div key="root" className={styles.Item} hidden={hidden} style={style}>

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -18,7 +18,7 @@ type KeyValueProps = {|
   inspectPath?: InspectPath,
   name: string,
   overrideValueFn?: ?OverrideValueFn,
-  path?: Array<any>,
+  path: Array<any>,
   value: any,
 |};
 
@@ -31,7 +31,7 @@ export default function KeyValue({
   hidden,
   name,
   overrideValueFn,
-  path = [],
+  path,
   value,
 }: KeyValueProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/src/devtools/views/Components/KeyValue.js
+++ b/src/devtools/views/Components/KeyValue.js
@@ -22,9 +22,6 @@ type KeyValueProps = {|
   value: any,
 |};
 
-// TODO (hydration) Don't display meta objects.
-// Add event listener to request a "read" instead.
-
 export default function KeyValue({
   depth,
   inspectPath,

--- a/src/devtools/views/Components/SelectedElement.js
+++ b/src/devtools/views/Components/SelectedElement.js
@@ -25,7 +25,7 @@ import {
 
 import styles from './SelectedElement.css';
 
-import type { GetPath } from './InspectedElementContext';
+import type { GetInspectedElementPath } from './InspectedElementContext';
 import type { Element, InspectedElement } from './types';
 import type { ElementType } from 'src/types';
 
@@ -39,7 +39,9 @@ export default function SelectedElement(_: Props) {
   const store = useContext(StoreContext);
   const { dispatch: modalDialogDispatch } = useContext(ModalDialogContext);
 
-  const { getPath, read } = useContext(InspectedElementContext);
+  const { getInspectedElementPath, getInspectedElement } = useContext(
+    InspectedElementContext
+  );
 
   const element =
     inspectedElementID !== null
@@ -47,7 +49,7 @@ export default function SelectedElement(_: Props) {
       : null;
 
   const inspectedElement =
-    inspectedElementID != null ? read(inspectedElementID) : null;
+    inspectedElementID != null ? getInspectedElement(inspectedElementID) : null;
 
   const highlightElement = useCallback(() => {
     if (element !== null && inspectedElementID !== null) {
@@ -202,10 +204,10 @@ export default function SelectedElement(_: Props) {
       {inspectedElement !== null && (
         <InspectedElementView
           key={
-            inspectedElementID /* Ensure state resets between seleted Elements */
+            inspectedElementID /* Force reset when seleted Element changes */
           }
           element={element}
-          getPath={getPath}
+          getInspectedElementPath={getInspectedElementPath}
           inspectedElement={inspectedElement}
         />
       )}
@@ -217,7 +219,7 @@ export type InspectPath = (path: Array<string | number>) => void;
 
 type InspectedElementViewProps = {|
   element: Element,
-  getPath: GetPath,
+  getInspectedElementPath: GetInspectedElementPath,
   inspectedElement: InspectedElement,
 |};
 
@@ -225,7 +227,7 @@ const IS_SUSPENDED = 'Suspended';
 
 function InspectedElementView({
   element,
-  getPath,
+  getInspectedElementPath,
   inspectedElement,
 }: InspectedElementViewProps) {
   const { id, type } = element;
@@ -247,21 +249,21 @@ function InspectedElementView({
 
   const inspectContextPath = useCallback(
     (path: Array<string | number>) => {
-      getPath(id, ['context', ...path]);
+      getInspectedElementPath(id, ['context', ...path]);
     },
-    [getPath, id]
+    [getInspectedElementPath, id]
   );
   const inspectPropsPath = useCallback(
     (path: Array<string | number>) => {
-      getPath(id, ['props', ...path]);
+      getInspectedElementPath(id, ['props', ...path]);
     },
-    [getPath, id]
+    [getInspectedElementPath, id]
   );
   const inspectStatePath = useCallback(
     (path: Array<string | number>) => {
-      getPath(id, ['state', ...path]);
+      getInspectedElementPath(id, ['state', ...path]);
     },
-    [getPath, id]
+    [getInspectedElementPath, id]
   );
 
   let overrideContextFn = null;

--- a/src/devtools/views/Components/types.js
+++ b/src/devtools/views/Components/types.js
@@ -83,6 +83,6 @@ export type InspectedElement = {|
 // TODO: Add profiling type
 
 export type DehydratedData = {|
-  cleaned: Array<Array<string>>,
+  cleaned: Array<Array<string | number>>,
   data: Object,
 |};

--- a/src/devtools/views/utils.js
+++ b/src/devtools/views/utils.js
@@ -91,7 +91,7 @@ export function getMetaValueLabel(data: Object): string | null {
     case 'data_view':
     case 'array':
     case 'typed_array':
-      return `${name}[${data[meta.meta].length}]`;
+      return `${name}[${data[meta.size]}]`;
     default:
       return null;
   }

--- a/src/hydration.js
+++ b/src/hydration.js
@@ -120,20 +120,6 @@ function createDehydrated(
   return dehydrated;
 }
 
-function isInspectedPath(
-  path: Array<string | number> = [],
-  inspectedPaths: Object
-): boolean {
-  let current = inspectedPaths;
-  for (let i = 0; i < path.length; i++) {
-    current = current[path[i]];
-    if (!current) {
-      return false;
-    }
-  }
-  return true;
-}
-
 /**
  * Strip out complex data (instances, functions, and data nested > LEVEL_THRESHOLD levels deep).
  * The paths of the stripped out objects are appended to the `cleaned` list.
@@ -156,7 +142,7 @@ export function dehydrate(
   data: Object,
   cleaned: Array<Array<string | number>>,
   path: Array<string | number>,
-  inspectedPaths: Object,
+  isPathWhitelisted: (path: Array<string | number>) => boolean,
   level?: number = 0
 ): string | Dehydrated | { [key: string]: string | Dehydrated } {
   const type = getPropType(data);
@@ -213,7 +199,7 @@ export function dehydrate(
       };
 
     case 'array':
-      const arrayPathCheck = isInspectedPath(path, inspectedPaths);
+      const arrayPathCheck = isPathWhitelisted(path);
       if (level >= LEVEL_THRESHOLD && !arrayPathCheck) {
         return createDehydrated(type, true, data, cleaned, path);
       }
@@ -222,7 +208,7 @@ export function dehydrate(
           item,
           cleaned,
           path.concat([i]),
-          inspectedPaths,
+          isPathWhitelisted,
           arrayPathCheck ? 1 : level + 1
         )
       );
@@ -240,7 +226,7 @@ export function dehydrate(
       };
 
     case 'object':
-      const objectPathCheck = isInspectedPath(path, inspectedPaths);
+      const objectPathCheck = isPathWhitelisted(path);
       if (level >= LEVEL_THRESHOLD && !objectPathCheck) {
         return createDehydrated(type, true, data, cleaned, path);
       } else {
@@ -250,7 +236,7 @@ export function dehydrate(
             data[name],
             cleaned,
             path.concat([name]),
-            inspectedPaths,
+            isPathWhitelisted,
             objectPathCheck ? 1 : level + 1
           );
         }

--- a/src/hydration.js
+++ b/src/hydration.js
@@ -41,9 +41,6 @@ type Dehydrated = {|
 //
 // Reducing this threshold will improve the speed of initial component inspection,
 // but may decrease the responsiveness of expanding objects/arrays to inspect further.
-//
-// Note that reducing the threshold to below 2 effectively breaks the inspected hooks interface.
-// It is only safe to dehydrate hooks within the "value" key, never within the "subHooks" array directly.
 const LEVEL_THRESHOLD = 2;
 
 /**

--- a/src/hydration.js
+++ b/src/hydration.js
@@ -42,7 +42,8 @@ type Dehydrated = {|
 // Reducing this threshold will improve the speed of initial component inspection,
 // but may decrease the responsiveness of expanding objects/arrays to inspect further.
 //
-// Note that reducing the threshold to below two effectively breaks the inspected hooks interface.
+// Note that reducing the threshold to below 2 effectively breaks the inspected hooks interface.
+// It is only safe to dehydrate hooks within the "value" key, never within the "subHooks" array directly.
 const LEVEL_THRESHOLD = 2;
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -245,3 +245,30 @@ export function shallowDiffers(prev: Object, next: Object): boolean {
   }
   return false;
 }
+
+export function getInObject(object: Object, path: Array<string | number>): any {
+  return path.reduce((reduced: Object, attr: string | number): any => {
+    if (typeof reduced === 'object' && reduced !== null) {
+      return reduced[attr];
+    } else if (Array.isArray(reduced)) {
+      return reduced[attr];
+    } else {
+      return null;
+    }
+  }, object);
+}
+
+export function setInObject(
+  object: Object,
+  path: Array<string | number>,
+  value: any
+) {
+  const length = path.length;
+  const last = path[length - 1];
+  if (object != null) {
+    const parent = getInObject(object, path.slice(0, length - 1));
+    if (parent) {
+      parent[last] = value;
+    }
+  }
+}


### PR DESCRIPTION
Resolves #195 (and generally improves performances for props-heavy components)

Prior to this change, inspecting a component serialized the first 5 nested levels of props/state/context data. This was okay for most cases- but in some extreme cases (objets with **a lot** of nested properties) this could cause a performance bottleneck. After this PR, we truncate nested objects much more aggressively. Now we only send their data over the bridge on-demand (similar to how v3 DevTools worked).

Internally, this technique is referred to as "dehydrating" and "hydrating" the values. Past a certain depth, nested values get "dehydrated" such that only metadata is sent across the bridge. The UI then requests these values be "hydrated" on-demand (when the user expands them) to fill in the missing data.

The old DevTools also had a pretty annoying behavior when it came to inspected props (see e.g. https://github.com/facebook/react-devtools/issues/1296, https://github.com/facebook/react-devtools/issues/1335). Specifically, when a component that had been "hydrated" updated, the hydration state was lost and all expanded paths were collapsed again. This PR does not preserve that behavior. Once a path has been "hydrated" it will not be dehydrated again by an update.

Here is a before (left) and after (right) comparison:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/29597/59627363-e3cf2680-90f2-11e9-8f3a-418d7fe53101.gif)