### PR TITLE
fix: ensure when-rendered content is never hidden

### DIFF
--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
@@ -10,6 +10,13 @@
 .Content {
   padding: 0.5rem;
   user-select: none;
+}
+
+.ContentShort {
+  overflow-y: visible;
+}
+
+.ContentMaybeLong {
   overflow-y: auto;
 }
 

--- a/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -74,7 +74,7 @@ export default function SidebarSelectedFiberInfo(_: Props) {
         profilerStore={profilerStore}
         rootID={((rootID: any): number)}
       />
-      <div className={styles.Content}>
+      <div className={`${styles.Content} ${styles.ContentMaybeLong}`}>
         {listItems.length > 0 && (
           <Fragment>
             <label className={styles.Label}>Rendered at</label>: {listItems}
@@ -116,7 +116,7 @@ function WhatChanged({
 
   if (changeDescription.isFirstMount) {
     return (
-      <div className={styles.Content}>
+      <div className={`${styles.Content} ${styles.ContentShort}`}>
         <label className={styles.Label}>Why did this render?</label>
         <div className={styles.WhatChangedItem}>
           This is the first time the component rendered.
@@ -199,7 +199,7 @@ function WhatChanged({
   }
 
   return (
-    <div className={styles.Content}>
+    <div className={`${styles.Content} ${styles.ContentShort}`}>
       <label className={styles.Label}>Why did this render?</label>
       {changes}
     </div>


### PR DESCRIPTION
Fixes #324.  This PR ensures that short sections of content in the profiler sidebar are always shown, even when there are a large number of renders shown in the sidebar. Without this PR, if there are many renders then the CSS `overflow-y: auto` would hide content like "why did this render?" until you scrolled down to see it, which is undiscoverable because there's no scrollbar or other indicator letting you know there's hidden content.

This PR divides sidebar content into "short" content (always show all of it without scrolling) and "maybe long" content (scrolling is OK). The "short" content gets `overflow-y: visible` while the "maybe long" content gets `overflow-y: auto`.

I tested locally in latest Chrome and latest Firefox and PR works as expected. 

For verification steps, see #324.