### PR TITLE
[Flare] Update event component displayName

### DIFF
--- a/src/backend/renderer.js
+++ b/src/backend/renderer.js
@@ -479,7 +479,7 @@ export function attach(
       case IndeterminateComponent:
         return getDisplayName(resolvedType);
       case EventComponent:
-        return type.displayName || 'EventComponent';
+        return type.responder.displayName || 'EventComponent';
       case EventTarget:
         switch (getTypeSymbol(elementType.type)) {
           case EVENT_TARGET_TOUCH_HIT_NUMBER:


### PR DESCRIPTION
This is for https://github.com/facebook/react/pull/15927 (if it lands). It updates the `displayName` location on event components.