### PR TITLE
Fix reload-and-profile attach not configurable

### DIFF
--- a/shells/browser/shared/src/renderer.js
+++ b/shells/browser/shared/src/renderer.js
@@ -15,6 +15,9 @@ Object.defineProperty(
   '__REACT_DEVTOOLS_ATTACH__',
   ({
     enumerable: false,
+    // This property needs to be configurable to allow third-party integrations
+    // to attach their own renderer. Note that using third-party integrations
+    // is not officially supported. Use at your own risk.
     configurable: true,
     get() {
       return attach;

--- a/shells/browser/shared/src/renderer.js
+++ b/shells/browser/shared/src/renderer.js
@@ -15,6 +15,7 @@ Object.defineProperty(
   '__REACT_DEVTOOLS_ATTACH__',
   ({
     enumerable: false,
+    configurable: true,
     get() {
       return attach;
     },


### PR DESCRIPTION
The devtools use a different way to attach the renderer with the "reload-and-profile" functionality. Before this PR it was setting it via a non-configurable object property making it impossible to set to something else. This breaks compatibility with third party clients like Preact.

Instead of going the `Object.defineProperty` way, we can just assign the property directly. Clicked a bit around in a sample CRA-App and both the standard devtools features as well as the reload-and-profile continue to work for me :tada: 