### PR TITLE
Feature: tweak search behaviour

### DIFF
--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -370,7 +370,7 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
         }
         break;
       case 'SET_SEARCH_TEXT':
-        searchIndex = 0;
+        searchIndex = null;
         searchResults = [];
         searchText = (action: ACTION_SET_SEARCH_TEXT).payload;
 
@@ -384,6 +384,8 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
               searchIndex = searchResults.findIndex(
                 value => value >= ((selectedElementID: any): number)
               );
+            } else {
+              searchIndex = 0;
             }
           }
         }

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -378,7 +378,7 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
         if (searchText !== '') {
           const regExp = createRegExp(searchText);
           store.roots.forEach(rootID => {
-            recursivelySearchTree(store, rootID, regExp, searchResults, selectedElementID, 0);
+            recursivelySearchTree(store, rootID, regExp, searchResults);
           });
 
           const firstIndexBiggerThanSelectedElement = searchResults.findIndex(

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -277,7 +277,6 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
     selectedElementIndex,
   } = state;
 
-  const prevSearchIndex = searchIndex;
   const prevSearchText = searchText;
   const numPrevSearchResults = searchResults.length;
 
@@ -383,6 +382,7 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
 
           if (searchResults.length > 0) {
             if (selectedElementID) {
+              // If there's an element selected, gets the nearest result
               searchIndex = searchResults.findIndex(
                 value => value >= selectedElementID
               );

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -784,7 +784,7 @@ function recursivelySearchTree(
   );
 }
 
-function getNearestResults (
+function getNearestResults(
   selectedElementID: number | null,
   searchResults: Array<number>
 ) {

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -774,7 +774,10 @@ function recursivelySearchTree(
   );
 }
 
-function getNearestResult(searchResults: Array<number>, selectedElementID: number | null){
+function getNearestResult(
+  searchResults: Array<number>,
+  selectedElementID: number | null
+) {
   const result = searchResults.findIndex(
     value => value >= ((selectedElementID: any): number)
   );

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -381,19 +381,13 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
             recursivelySearchTree(store, rootID, regExp, searchResults);
           });
 
-          const searchWithNearestResults = getNearestResults(
-            selectedElementID,
-            searchResults
-          );
-
-          if (searchWithNearestResults.length > 0) {
-            if (prevSearchIndex === null) {
-              searchIndex = 0;
-            } else {
-              searchIndex = Math.min(
-                ((prevSearchIndex: any): number),
-                searchWithNearestResults.length - 1
+          if (searchResults.length > 0) {
+            if (selectedElementID) {
+              searchIndex = searchResults.findIndex(
+                value => value >= selectedElementID
               );
+            } else {
+              searchIndex = 0;
             }
           }
         }
@@ -782,25 +776,6 @@ function recursivelySearchTree(
   children.forEach(childID =>
     recursivelySearchTree(store, childID, regExp, searchResults)
   );
-}
-
-function getNearestResults(
-  selectedElementID: number | null,
-  searchResults: Array<number>
-) {
-  let searchWithNearestResults = searchResults;
-  if (selectedElementID) {
-    const firstIndexBiggerThanSelectedElement = searchResults.findIndex(
-      value => value > selectedElementID
-    );
-
-    searchWithNearestResults = [
-      ...searchResults.slice(firstIndexBiggerThanSelectedElement),
-      ...searchResults.slice(0, firstIndexBiggerThanSelectedElement),
-    ];
-  }
-
-  return searchWithNearestResults;
 }
 
 export { TreeDispatcherContext, TreeStateContext, TreeContextController };

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -370,7 +370,7 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
         }
         break;
       case 'SET_SEARCH_TEXT':
-        searchIndex = null;
+        searchIndex = 0;
         searchResults = [];
         searchText = (action: ACTION_SET_SEARCH_TEXT).payload;
 
@@ -379,15 +379,11 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
           store.roots.forEach(rootID => {
             recursivelySearchTree(store, rootID, regExp, searchResults);
           });
-
           if (searchResults.length > 0) {
             if (selectedElementID !== null) {
-              // If there's an element selected, gets the nearest result
               searchIndex = searchResults.findIndex(
-                value => value >= selectedElementID
+                value => value >= ((selectedElementID: any): number)
               );
-            } else {
-              searchIndex = 0;
             }
           }
         }

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -381,9 +381,10 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
             recursivelySearchTree(store, rootID, regExp, searchResults);
           });
 
-          const firstIndexBiggerThanSelectedElement = searchResults.findIndex(
-            value => value > selectedElementID
-          );
+          const firstIndexBiggerThanSelectedElement =
+            selectedElementID &&
+            searchResults.findIndex(value => value > selectedElementID);
+
           const searchWithNearestResults = [
             ...searchResults.slice(firstIndexBiggerThanSelectedElement),
             ...searchResults.slice(0, firstIndexBiggerThanSelectedElement),

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -381,9 +381,7 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
           });
           if (searchResults.length > 0) {
             if (selectedElementID !== null) {
-              searchIndex = searchResults.findIndex(
-                value => value >= ((selectedElementID: any): number)
-              );
+              searchIndex = getNearestResult(searchResults, selectedElementID);
             } else {
               searchIndex = 0;
             }
@@ -774,6 +772,14 @@ function recursivelySearchTree(
   children.forEach(childID =>
     recursivelySearchTree(store, childID, regExp, searchResults)
   );
+}
+
+function getNearestResult(searchResults: Array<number>, selectedElementID: number | null){
+  const result = searchResults.findIndex(
+    value => value >= ((selectedElementID: any): number)
+  );
+
+  return result === -1 ? 0 : result;
 }
 
 export { TreeDispatcherContext, TreeStateContext, TreeContextController };

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -382,12 +382,12 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
 
           if (searchResults.length > 0) {
             if (selectedElementID !== null) {
-              searchIndex = 0;
-            } else {
               // If there's an element selected, gets the nearest result
               searchIndex = searchResults.findIndex(
                 value => value >= selectedElementID
               );
+            } else {
+              searchIndex = 0;
             }
           }
         }

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -381,13 +381,13 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
           });
 
           if (searchResults.length > 0) {
-            if (selectedElementID) {
+            if (selectedElementID !== null) {
+              searchIndex = 0;
+            } else {
               // If there's an element selected, gets the nearest result
               searchIndex = searchResults.findIndex(
                 value => value >= selectedElementID
               );
-            } else {
-              searchIndex = 0;
             }
           }
         }

--- a/src/devtools/views/Components/TreeContext.js
+++ b/src/devtools/views/Components/TreeContext.js
@@ -381,14 +381,10 @@ function reduceSearchState(store: Store, state: State, action: Action): State {
             recursivelySearchTree(store, rootID, regExp, searchResults);
           });
 
-          const firstIndexBiggerThanSelectedElement =
-            selectedElementID &&
-            searchResults.findIndex(value => value > selectedElementID);
-
-          const searchWithNearestResults = [
-            ...searchResults.slice(firstIndexBiggerThanSelectedElement),
-            ...searchResults.slice(0, firstIndexBiggerThanSelectedElement),
-          ];
+          const searchWithNearestResults = getNearestResults(
+            selectedElementID,
+            searchResults
+          );
 
           if (searchWithNearestResults.length > 0) {
             if (prevSearchIndex === null) {
@@ -786,6 +782,25 @@ function recursivelySearchTree(
   children.forEach(childID =>
     recursivelySearchTree(store, childID, regExp, searchResults)
   );
+}
+
+function getNearestResults (
+  selectedElementID: number | null,
+  searchResults: Array<number>
+) {
+  let searchWithNearestResults = searchResults;
+  if (selectedElementID) {
+    const firstIndexBiggerThanSelectedElement = searchResults.findIndex(
+      value => value > selectedElementID
+    );
+
+    searchWithNearestResults = [
+      ...searchResults.slice(firstIndexBiggerThanSelectedElement),
+      ...searchResults.slice(0, firstIndexBiggerThanSelectedElement),
+    ];
+  }
+
+  return searchWithNearestResults;
 }
 
 export { TreeDispatcherContext, TreeStateContext, TreeContextController };


### PR DESCRIPTION
This pr closes #301 

The strategy used here was: Get the first index where elementID is larger than the selected element and reorder the search results for these elements so that the range with the largest is at the beginning of the matrix and the range with the smallest in the end.