### PR TITLE
Allow Inspecting Elements Within Iframes

### DIFF
--- a/shells/dev/app/Iframe/index.js
+++ b/shells/dev/app/Iframe/index.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default function Iframe() {
+  return (
+    <>
+      <h2>Iframe</h2>
+      <div>
+        <Frame>
+          <Greeting />
+        </Frame>
+      </div>
+    </>
+  );
+}
+
+const iframeStyle = { border: '2px solid #eee', height: 80 };
+
+function Frame(props) {
+  const [element, setElement] = React.useState(null);
+
+  const ref = React.useRef();
+
+  React.useLayoutEffect(function() {
+    const iframe = ref.current;
+
+    if (iframe) {
+      const html = `
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <div id="root"></div>
+    </body>
+    </html>
+    `;
+
+      const document = iframe.contentDocument;
+
+      document.open();
+      document.write(html);
+      document.close();
+
+      setElement(document.getElementById('root'));
+    }
+  }, []);
+
+  return (
+    <>
+      <iframe title="Test Iframe" ref={ref} style={iframeStyle} />
+      <iframe
+        title="Secured Iframe"
+        src="https://example.com"
+        style={iframeStyle}
+      />
+
+      {element ? ReactDOM.createPortal(props.children, element) : null}
+    </>
+  );
+}
+
+function Greeting() {
+  return (
+    <p>
+      Hello from within an <code>&lt;iframe&gt;</code>!
+    </p>
+  );
+}

--- a/shells/dev/app/index.js
+++ b/shells/dev/app/index.js
@@ -8,6 +8,7 @@ import {
   unstable_createRoot as createRoot,
 } from 'react-dom';
 import DeeplyNestedComponents from './DeeplyNestedComponents';
+import Iframe from './Iframe';
 import EditableProps from './EditableProps';
 import ElementTypes from './ElementTypes';
 import Hydration from './Hydration';
@@ -46,6 +47,7 @@ function mountTestApp() {
   mountHelper(Toggle);
   mountHelper(SuspenseTree);
   mountHelper(DeeplyNestedComponents);
+  mountHelper(Iframe);
 }
 
 function unmountTestApp() {

--- a/src/backend/agent.js
+++ b/src/backend/agent.js
@@ -185,13 +185,15 @@ export default class Agent extends EventEmitter<{|
 
   getIDForNode(node: Object): number | null {
     for (let rendererID in this._rendererInterfaces) {
-      // A renderer will throw if it can't find a fiber for the specified node.
-      try {
-        const renderer = ((this._rendererInterfaces[
-          (rendererID: any)
-        ]: any): RendererInterface);
-        return renderer.getFiberIDForNative(node, true);
-      } catch (e) {}
+      const renderer = ((this._rendererInterfaces[
+        (rendererID: any)
+      ]: any): RendererInterface);
+
+      const id = renderer.getFiberIDForNative(node, true);
+
+      if (id !== null) {
+        return id;
+      }
     }
     return null;
   }

--- a/src/backend/views/Highlighter/index.js
+++ b/src/backend/views/Highlighter/index.js
@@ -48,7 +48,11 @@ export default function setupHighlighter(
     hideOverlay();
     removeListenersOnWindow(window);
     iframesListeningTo.forEach(function(frame) {
-      removeListenersOnWindow(frame.contentWindow);
+      try {
+        removeListenersOnWindow(frame.contentWindow);
+      } catch (error) {
+        // This can error when the iframe is on a cross-origin.
+      }
     });
     iframesListeningTo = new Set();
   }

--- a/src/backend/views/Highlighter/index.js
+++ b/src/backend/views/Highlighter/index.js
@@ -12,7 +12,7 @@ import type { BackendBridge } from 'src/bridge';
 // It is not currently the mechanism used to highlight React Native views.
 // That is done by the React Native Inspector component.
 
-let iframesListeningTo = new Set();
+let iframesListeningTo: Set<HTMLIFrameElement> = new Set();
 
 export default function setupHighlighter(
   bridge: BackendBridge,
@@ -144,11 +144,12 @@ export default function setupHighlighter(
     const target = ((event.target: any): HTMLElement);
 
     if (target.tagName === 'IFRAME') {
+      const iframe: HTMLIFrameElement = (target: any);
       try {
-        if (!iframesListeningTo.has(target)) {
-          const window = target.contentWindow;
+        if (!iframesListeningTo.has(iframe)) {
+          const window = iframe.contentWindow;
           registerListenersOnWindow(window);
-          iframesListeningTo.add(target);
+          iframesListeningTo.add(iframe);
         }
       } catch (error) {
         // This can error when the iframe is on a cross-origin.


### PR DESCRIPTION
This change adds support for element inspecting within `<iframe/>`s.

The iframes are kept in a Set so that we only append listeners once and clean them up properly. I’ve run a few tests and it seems to behave as expected.

Here’s a screencapture: http://cl.ly/358a8f22715d/iframe-demo.mov

The fixture includes a cross-origin iframe to make sure we do not error in this case.

I’ve run through the following scenarios locally:

- Nexted iframes
- Iframe is removed while we’re inspecting
- Chrome and Firefox

Let me know if/where I should add tests. 🙂