### PR TITLE
Refactor inspect/select logic so that $r contains hooks data

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -112,8 +112,8 @@ export function connectToDevTools(options: ?ConnectOptions) {
       },
     });
     bridge.addListener(
-      'selectElement',
-      ({ id, rendererID }: {| id: number, rendererID: number |}) => {
+      'inspectElement',
+      ({ id, rendererID }: { id: number, rendererID: number }) => {
         const renderer = agent.rendererInterfaces[rendererID];
         if (renderer != null) {
           // Send event for RN to highlight.

--- a/src/backend/legacy/renderer.js
+++ b/src/backend/legacy/renderer.js
@@ -633,6 +633,7 @@ export function attach(
         };
         break;
       default:
+        global.$r = null;
         break;
     }
   }

--- a/src/backend/legacy/renderer.js
+++ b/src/backend/legacy/renderer.js
@@ -609,6 +609,34 @@ export function attach(
     };
   }
 
+  function updateSelectedElement(id: number): void {
+    const internalInstance = idToInternalInstanceMap.get(id);
+    if (internalInstance == null) {
+      console.warn(`Could not find instance with id "${id}"`);
+      return;
+    }
+
+    switch (getElementType(internalInstance)) {
+      case ElementTypeClass:
+        global.$r = internalInstance._instance;
+        break;
+      case ElementTypeFunction:
+        const element = internalInstance._currentElement;
+        if (element == null) {
+          console.warn(`Could not find element with id "${id}"`);
+          return;
+        }
+
+        global.$r = {
+          props: element.props,
+          type: element.type,
+        };
+        break;
+      default:
+        break;
+    }
+  }
+
   function inspectElement(
     id: number,
     path?: Array<string | number>
@@ -629,6 +657,11 @@ export function attach(
     if (path != null) {
       mergeInspectedPaths(path);
     }
+
+    // Any time an inspected element has an update,
+    // we should update the selected $r value as wel.
+    // Do this before dehyration (cleanForBridge).
+    updateSelectedElement(id);
 
     inspectedElement.context = cleanForBridge(
       inspectedElement.context,
@@ -777,34 +810,6 @@ export function attach(
     global.$type = element.type;
   }
 
-  function selectElement(id: number): void {
-    const internalInstance = idToInternalInstanceMap.get(id);
-    if (internalInstance == null) {
-      console.warn(`Could not find instance with id "${id}"`);
-      return;
-    }
-
-    switch (getElementType(internalInstance)) {
-      case ElementTypeClass:
-        global.$r = internalInstance._instance;
-        break;
-      case ElementTypeFunction:
-        const element = internalInstance._currentElement;
-        if (element == null) {
-          console.warn(`Could not find element with id "${id}"`);
-          return;
-        }
-
-        global.$r = {
-          props: element.props,
-          type: element.type,
-        };
-        break;
-      default:
-        break;
-    }
-  }
-
   function setInProps(id: number, path: Array<string | number>, value: any) {
     const internalInstance = idToInternalInstanceMap.get(id);
     if (internalInstance != null) {
@@ -918,7 +923,6 @@ export function attach(
     overrideSuspense,
     prepareViewElementSource,
     renderer,
-    selectElement,
     setInContext,
     setInHook,
     setInProps,

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -299,7 +299,6 @@ export type RendererInterface = {
   overrideSuspense: (id: number, forceFallback: boolean) => void,
   prepareViewElementSource: (id: number) => void,
   renderer: ReactRenderer | null,
-  selectElement: (id: number) => void,
   setInContext: (id: number, path: Array<string | number>, value: any) => void,
   setInHook: (
     id: number,

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -99,7 +99,6 @@ type FrontendEvents = {|
   overrideSuspense: [OverrideSuspense],
   profilingData: [ProfilingDataBackend],
   reloadAndProfile: [boolean],
-  selectElement: [ElementAndRendererID],
   selectFiber: [number],
   shutdown: [],
   startInspectingNative: [],

--- a/src/devtools/views/Components/InspectedElementContext.js
+++ b/src/devtools/views/Components/InspectedElementContext.js
@@ -241,11 +241,6 @@ function InspectedElementContextController({ children }: Props) {
     // We'll poll for an update in the response handler below.
     sendRequest();
 
-    // Update the $r variable.
-    if (rendererID !== null) {
-      bridge.send('selectElement', { id: selectedElementID, rendererID });
-    }
-
     const onInspectedElement = (data: InspectedElementPayload) => {
       // If this is the element we requested, wait a little bit and then ask for another update.
       if (data.id === selectedElementID) {


### PR DESCRIPTION
Closes #357

This change enables a few things:
* Removes a redundant `Bridge` message.
* Enables `$r` to include hooks info for function components.
* Ensures `$r` is periodically updated if the selected element is re-rendered.

One thing to note is that the `hooks` value exposed is the internal data structure created by [`react-debug-hooks`](https://github.com/bvaughn/react-devtools-experimental/blob/master/src/backend/ReactDebugHooks.js) so it isn't necessarily as parsable or useful as the `props` or `state` objects. Still seems better than nothing though?

<img width="715" alt="Screen Shot 2019-08-03 at 5 55 02 PM" src="https://user-images.githubusercontent.com/29597/62418146-da087080-b617-11e9-8ffc-f6d67aad82ed.png">
